### PR TITLE
Implements wrestler heal chance

### DIFF
--- a/src/test/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationServiceTest.java
@@ -138,22 +138,6 @@ class SegmentAdjudicationServiceTest {
   }
 
   @Test
-  void testAdjudicateMatch_AssignsBumpsToLosers() {
-    // Given
-    when(random.nextInt(anyInt())).thenReturn(10); // Mock the dice roll for non-promo
-    segment.setWinners(List.of(champion)); // Champion is winner
-
-    // When
-    segmentAdjudicationService.adjudicateMatch(segment);
-
-    // Then
-    Assertions.assertNotNull(challenger.getId());
-    verify(wrestlerService, times(1)).addBump(challenger.getId());
-    Assertions.assertNotNull(champion.getId());
-    verify(wrestlerService, never()).addBump(champion.getId());
-  }
-
-  @Test
   void testAdjudicateMatch_AddsHeatToFeuds() {
     // Given
     // Create a new segment for this test to avoid interference from setUp
@@ -213,5 +197,21 @@ class SegmentAdjudicationServiceTest {
     // non-promo)
     Assertions.assertNotNull(feud.getId());
     verify(feudService, times(1)).addHeat(feud.getId(), 1, "From segment: Test Match");
+  }
+
+  @Test
+  void testAdjudicateMatch_AssignsBumpsToLosers() {
+    // Given
+    when(random.nextInt(anyInt())).thenReturn(10); // Mock the dice roll for non-promo
+    segment.setWinners(List.of(champion)); // Champion is winner
+
+    // When
+    segmentAdjudicationService.adjudicateMatch(segment);
+
+    // Then
+    Assertions.assertNotNull(challenger.getId());
+    verify(wrestlerService, times(1)).addBump(challenger.getId());
+    Assertions.assertNotNull(champion.getId());
+    verify(wrestlerService, never()).addBump(champion.getId());
   }
 }

--- a/src/test/java/com/github/javydreamercsw/management/service/show/ShowServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/show/ShowServiceTest.java
@@ -7,8 +7,12 @@ import com.github.javydreamercsw.management.domain.show.Show;
 import com.github.javydreamercsw.management.domain.show.ShowRepository;
 import com.github.javydreamercsw.management.domain.show.segment.Segment;
 import com.github.javydreamercsw.management.domain.show.segment.SegmentRepository;
+import com.github.javydreamercsw.management.domain.show.segment.type.SegmentType;
+import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.service.match.SegmentAdjudicationService;
+import com.github.javydreamercsw.management.service.wrestler.WrestlerService;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,27 +27,51 @@ class ShowServiceTest {
 
   @Mock private ShowRepository showRepository;
   @Mock private SegmentRepository segmentRepository;
+  @Mock private WrestlerService wrestlerService;
   @Mock private SegmentAdjudicationService segmentAdjudicationService;
   @Mock private ApplicationEventPublisher eventPublisher; // Needed to avoid NPE
 
   @InjectMocks private ShowService showService;
 
   private Show show;
+  private Segment segment;
   private Segment pendingSegment;
   private Segment adjudicatedSegment;
+  private Wrestler wrestler1;
+  private Wrestler wrestler2;
+  private Wrestler wrestler3;
 
   @BeforeEach
   void setUp() {
     show = new Show();
     show.setId(1L);
 
+    segment = new Segment();
+    segment.setId(1L);
+    segment.setShow(show);
+    SegmentType segmentType = new SegmentType();
+    segmentType.setName("Promo");
+    segment.setSegmentType(segmentType);
+    segment.setAdjudicationStatus(AdjudicationStatus.PENDING);
+
+    SegmentType pendingSegmentType = new SegmentType();
+    pendingSegmentType.setName("One on One");
+
     pendingSegment = new Segment();
     pendingSegment.setId(10L);
+    pendingSegment.setSegmentType(pendingSegmentType);
     pendingSegment.setAdjudicationStatus(AdjudicationStatus.PENDING);
 
     adjudicatedSegment = new Segment();
     adjudicatedSegment.setId(11L);
     adjudicatedSegment.setAdjudicationStatus(AdjudicationStatus.ADJUDICATED);
+
+    wrestler1 = new Wrestler();
+    wrestler1.setId(1L);
+    wrestler2 = new Wrestler();
+    wrestler2.setId(2L);
+    wrestler3 = new Wrestler();
+    wrestler3.setId(3L);
   }
 
   @Test
@@ -52,6 +80,7 @@ class ShowServiceTest {
     when(segmentRepository.findByShow(show))
         .thenReturn(Arrays.asList(pendingSegment, adjudicatedSegment));
 
+    // When
     showService.adjudicateShow(1L);
 
     verify(segmentAdjudicationService, times(1)).adjudicateMatch(pendingSegment);
@@ -61,5 +90,24 @@ class ShowServiceTest {
     verify(segmentRepository, never()).save(adjudicatedSegment);
 
     assert (pendingSegment.getAdjudicationStatus() == AdjudicationStatus.ADJUDICATED);
+  }
+
+  @Test
+  void testAdjudicateShow_HealsNonParticipatingWrestlers() {
+    // Given
+    segment.addParticipant(wrestler1);
+    segment.addParticipant(wrestler2);
+
+    when(showRepository.findById(1L)).thenReturn(Optional.of(show));
+    when(segmentRepository.findByShow(show)).thenReturn(List.of(segment));
+    when(wrestlerService.findAll()).thenReturn(List.of(wrestler1, wrestler2, wrestler3));
+
+    // When
+    showService.adjudicateShow(1L);
+
+    // Then
+    verify(wrestlerService, times(1)).healChance(wrestler3.getId());
+    verify(wrestlerService, never()).healChance(wrestler1.getId());
+    verify(wrestlerService, never()).healChance(wrestler2.getId());
   }
 }


### PR DESCRIPTION
Implements a mechanic where wrestlers who do not participate in a show segment have a chance to heal injuries or reduce bumps.

This change:
- Adds a `healChance` method to the `WrestlerService` that attempts to heal injuries and reduce bumps for a wrestler.
- Adds a `getNonParticipatingWrestlers` method to the `ShowService` to identify wrestlers who did not participate in a show.
- Modifies the `adjudicateShow` method to call the `healChance` method for non-participating wrestlers.