### PR TITLE
fix(ai): ensure AI respects match feedback and story beats (#280)

### DIFF
--- a/src/main/java/com/github/javydreamercsw/base/ai/AbstractSegmentNarrationService.java
+++ b/src/main/java/com/github/javydreamercsw/base/ai/AbstractSegmentNarrationService.java
@@ -154,6 +154,12 @@ public abstract class AbstractSegmentNarrationService implements SegmentNarratio
     prompt.append("Here is the JSON context:\n\n");
     prompt.append(jsonContext);
 
+    prompt.append(
+        "\n\nIMPORTANT - EXISTING STORY BEATS: If instructions contain 'Existing Description/Story"
+            + " Beats', you MUST treat them as mandatory plot points that must occur in your"
+            + " narration. Expand upon them with dialogue and action, but DO NOT contradict or"
+            + " ignore them. They represent the established plan for this segment.\n\n");
+
     log.debug("Generated AI Prompt: {}", prompt);
     return prompt.toString();
   }

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ProposedSegment.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ProposedSegment.java
@@ -26,6 +26,7 @@ public class ProposedSegment {
   private String type; // "segment" or "promo"
   private String narration;
   private String summary;
+  private String notes;
   private List<String> participants;
   private List<String> winners;
   private Boolean isTitleSegment = false;

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiService.java
@@ -91,6 +91,7 @@ public class ShowPlanningAiService {
                     segment.setType(dto.getType());
                     segment.setNarration(dto.getDescription());
                     segment.setSummary(dto.getOutcome());
+                    segment.setNotes(dto.getNotes());
                     segment.setParticipants(dto.getParticipants());
                     return segment;
                   })
@@ -362,6 +363,8 @@ public class ShowPlanningAiService {
     }
     prompt.append("  \"description\": \"string\",\n");
     prompt.append("  \"outcome\": \"string\",\n");
+    prompt.append(
+        "  \"notes\": \"string\", // Optional instructions/feedback for future AI narration\n");
     prompt.append("  \"participants\": [\"string\"]\n");
     prompt.append("}\n");
     prompt.append("```\n\n");

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningService.java
@@ -273,6 +273,7 @@ public class ShowPlanningService {
       segment.setSegmentDate(show.getShowDate().atStartOfDay(clock.getZone()).toInstant());
       segment.setNarration(proposedSegment.getNarration());
       segment.setSummary(proposedSegment.getSummary());
+      segment.setNotes(proposedSegment.getNotes());
       segment.setSegmentOrder(currentSegmentCount + i + 1);
       segment.setIsTitleSegment(proposedSegment.getIsTitleSegment());
       if (proposedSegment.getTitles() != null && !proposedSegment.getTitles().isEmpty()) {

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/dto/AiGeneratedSegmentDTO.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/dto/AiGeneratedSegmentDTO.java
@@ -28,5 +28,6 @@ public class AiGeneratedSegmentDTO {
   private String type; // e.g., "match", "promo", "interview", "angle"
   private String description;
   private String outcome;
+  private String notes;
   private java.util.List<String> participants;
 }

--- a/src/main/java/com/github/javydreamercsw/management/ui/view/match/MatchView.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/view/match/MatchView.java
@@ -16,6 +16,7 @@
 */
 package com.github.javydreamercsw.management.ui.view.match;
 
+import com.github.javydreamercsw.base.ai.SegmentNarrationService.CampaignContext;
 import com.github.javydreamercsw.base.ai.SegmentNarrationService.CommentatorContext;
 import com.github.javydreamercsw.base.ai.SegmentNarrationService.NPCContext;
 import com.github.javydreamercsw.base.ai.SegmentNarrationService.SegmentNarrationContext;
@@ -26,6 +27,7 @@ import com.github.javydreamercsw.base.ai.SegmentNarrationServiceFactory;
 import com.github.javydreamercsw.base.security.CustomUserDetails;
 import com.github.javydreamercsw.base.security.SecurityUtils;
 import com.github.javydreamercsw.management.domain.campaign.CampaignRepository;
+import com.github.javydreamercsw.management.domain.campaign.CampaignState;
 import com.github.javydreamercsw.management.domain.commentator.CommentaryTeam;
 import com.github.javydreamercsw.management.domain.commentator.CommentaryTeamRepository;
 import com.github.javydreamercsw.management.domain.league.MatchFulfillment;
@@ -868,6 +870,12 @@ public class MatchView extends VerticalLayout implements BeforeEnterObserver {
         instructions += "\n\nPlease also incorporate this specific feedback: " + feedback;
       }
 
+      if (segment.getNarration() != null && !segment.getNarration().isBlank()) {
+        instructions +=
+            "\n\nExisting Description/Story Beats (MUST be expanded and followed):\n"
+                + segment.getNarration();
+      }
+
       if (segment.getReferee() != null) {
         instructions +=
             "\n\nThe assigned referee for this match is: " + segment.getReferee().getName() + ".";
@@ -878,6 +886,42 @@ public class MatchView extends VerticalLayout implements BeforeEnterObserver {
       // Apply Title Effects
       if (segment.getIsTitleSegment() && !segment.getTitles().isEmpty()) {
         titleScriptService.applyTitleEffects(context, segment.getTitles());
+      }
+
+      // Campaign Context
+      Wrestler playerWrestler =
+          securityUtils.getAuthenticatedUser().map(CustomUserDetails::getWrestler).orElse(null);
+      if (playerWrestler != null) {
+        campaignRepository
+            .findActiveByWrestler(playerWrestler)
+            .ifPresent(
+                campaign -> {
+                  CampaignState state = campaign.getState();
+                  if (state != null) {
+                    CampaignContext cc = new CampaignContext();
+                    try {
+                      cc.setChapter(Integer.parseInt(state.getCurrentChapterId()));
+                    } catch (NumberFormatException e) {
+                      cc.setChapter(0);
+                    }
+                    cc.setAlignmentType(
+                        playerWrestler.getAlignment() != null
+                            ? playerWrestler.getAlignment().getAlignmentType().name()
+                            : "NEUTRAL");
+                    cc.setAlignmentLevel(
+                        playerWrestler.getAlignment() != null
+                            ? playerWrestler.getAlignment().getLevel()
+                            : 0);
+                    cc.setCurrentRival(
+                        state.getRival() != null ? state.getRival().getName() : null);
+                    cc.setActiveInjuries(
+                        playerWrestler.getActiveInjuries().stream()
+                            .map(com.github.javydreamercsw.management.domain.injury.Injury::getName)
+                            .toList());
+
+                    context.setCampaignContext(cc);
+                  }
+                });
       }
 
       String generated = narrationServiceFactory.getBestAvailableService().narrateSegment(context);

--- a/src/main/java/com/github/javydreamercsw/management/ui/view/show/EditSegmentDialog.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/view/show/EditSegmentDialog.java
@@ -52,6 +52,7 @@ public class EditSegmentDialog extends Dialog {
   private final com.github.javydreamercsw.management.service.npc.NpcService npcService;
   private final Runnable onSave;
   @Getter private final TextArea narrationArea;
+  @Getter private final TextArea notesArea;
   @Getter private final MultiSelectComboBox<Wrestler> participantsCombo;
 
   private final ComboBox<com.github.javydreamercsw.management.domain.npc.Npc> refereeCombo;
@@ -226,6 +227,13 @@ public class EditSegmentDialog extends Dialog {
     narrationArea.setId("edit-narration-text-area");
     formLayout.setColspan(narrationArea, 2);
 
+    notesArea = new TextArea("Match Feedback / Notes");
+    notesArea.setWidthFull();
+    notesArea.setValue(segment.getNotes() != null ? segment.getNotes() : "");
+    notesArea.setId("edit-notes-text-area");
+    notesArea.setPlaceholder("Provide specific instructions for the AI narration...");
+    formLayout.setColspan(notesArea, 2);
+
     titleMultiSelectComboBox = new MultiSelectComboBox<>("Titles");
     titleMultiSelectComboBox.setItems(titleService.findAll());
     titleMultiSelectComboBox.setItemLabelGenerator(Title::getName);
@@ -259,6 +267,7 @@ public class EditSegmentDialog extends Dialog {
         isTitleSegmentCheckbox,
         titleMultiSelectComboBox,
         summaryArea,
+        notesArea,
         narrationArea);
 
     saveButton = new Button("Save", e -> save());
@@ -309,6 +318,7 @@ public class EditSegmentDialog extends Dialog {
     segment.setType(segmentTypeCombo.getValue().getName());
     segment.setNarration(narrationArea.getValue());
     segment.setSummary(summaryArea.getValue());
+    segment.setNotes(notesArea.getValue());
     segment.setParticipants(
         participantsCombo.getValue().stream().map(Wrestler::getName).collect(Collectors.toList()));
     segment.setWinners(

--- a/src/test/java/com/github/javydreamercsw/base/ai/AbstractSegmentNarrationServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/base/ai/AbstractSegmentNarrationServiceTest.java
@@ -86,5 +86,8 @@ class AbstractSegmentNarrationServiceTest {
     assertTrue(
         prompt.contains("\"culturalTags\" : [ \"Underground\" ]"),
         "Prompt should contain culturalTags");
+    assertTrue(
+        prompt.contains("IMPORTANT - EXISTING STORY BEATS"),
+        "Prompt should contain instructions for existing story beats");
   }
 }

--- a/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiServiceTest.java
@@ -122,7 +122,8 @@ class ShowPlanningAiServiceTest {
             "segmentId": "seg1",
             "type": "One on One",
             "description": "Main Event: John Cena vs Randy Orton",
-            "outcome": "John Cena wins"
+            "outcome": "John Cena wins",
+            "notes": "End with a dramatic finisher"
           },
           {
             "segmentId": "seg2",
@@ -145,6 +146,7 @@ class ShowPlanningAiServiceTest {
     ProposedSegment segment1 = proposedShow.getSegments().get(0);
     assertEquals("One on One", segment1.getType());
     assertEquals("Main Event: John Cena vs Randy Orton", segment1.getNarration());
+    assertEquals("End with a dramatic finisher", segment1.getNotes());
 
     ProposedSegment segment2 = proposedShow.getSegments().get(1);
     assertEquals("Promo", segment2.getType());
@@ -155,6 +157,7 @@ class ShowPlanningAiServiceTest {
     verify(narrationServiceFactory, times(1)).generateText(promptCaptor.capture());
 
     String capturedPrompt = promptCaptor.getValue();
+    assertTrue(capturedPrompt.contains("\"notes\": \"string\""));
     assertTrue(
         capturedPrompt.contains(
             "Available Segment Types: One on One (A standard wrestling match between two"

--- a/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningServiceTest.java
@@ -105,6 +105,7 @@ class ShowPlanningServiceTest {
     proposedSegment.setType("Singles Match");
     proposedSegment.setNarration("A great match");
     proposedSegment.setSummary("A summary of the match");
+    proposedSegment.setNotes("AI should focus on technical wrestling");
     proposedSegment.setParticipants(List.of("Wrestler A", "Wrestler B"));
     proposedSegment.setWinners(List.of("Wrestler A"));
     proposedSegment.setIsTitleSegment(true);
@@ -146,6 +147,7 @@ class ShowPlanningServiceTest {
 
     assertEquals("A great match", capturedSegment.getNarration());
     assertEquals("A summary of the match", capturedSegment.getSummary());
+    assertEquals("AI should focus on technical wrestling", capturedSegment.getNotes());
     assertTrue(capturedSegment.getIsTitleSegment());
     assertEquals(1, capturedSegment.getTitles().size());
     assertEquals("World Championship", capturedSegment.getTitles().iterator().next().getName());


### PR DESCRIPTION
- Added 'notes' field to ProposedSegment and AiGeneratedSegmentDTO to support feedback during planning.
- Enhanced EditSegmentDialog with a 'Match Feedback' area to allow early instruction input.
- Updated ShowPlanningService to persist planning notes into the database.
- Modified MatchView to send both existing narration (story beats) and notes to the AI.
- Fixed a bug where CampaignContext was sent empty to the AI; now populates chapter, alignment, and injuries.
- Updated AI instructions to explicitly prioritize existing story beats in the narration.
- Added and updated tests in ShowPlanningServiceTest, ShowPlanningAiServiceTest, and AbstractSegmentNarrationServiceTest.