### PR TITLE
fix(ATW-ep5): consistently filter Show, Title, League list views by current universe

### DIFF
--- a/src/main/java/com/github/javydreamercsw/management/ui/view/league/LeagueListView.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/view/league/LeagueListView.java
@@ -222,13 +222,10 @@ public class LeagueListView extends Main {
         .getAuthenticatedUser()
         .ifPresent(
             user -> {
+              Long universeId = universeContextService.getCurrentUniverseId();
               List<League> leagues = leagueService.getLeaguesForUser(user.getAccount());
-              universeContextService
-                  .getCurrentUniverse()
-                  .ifPresent(
-                      u ->
-                          leagues.removeIf(
-                              l -> l.getUniverse() == null || !u.equals(l.getUniverse())));
+              leagues.removeIf(
+                  l -> l.getUniverse() == null || !universeId.equals(l.getUniverse().getId()));
               leagueGrid.setItems(leagues);
             });
   }

--- a/src/main/java/com/github/javydreamercsw/management/ui/view/show/ShowListView.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/view/show/ShowListView.java
@@ -514,11 +514,10 @@ public class ShowListView extends Main {
   }
 
   private void refreshGrid() {
-    universeContextService
-        .getCurrentUniverse()
-        .ifPresentOrElse(
-            u -> showGrid.setItems(showService.getShowsByUniverse(u)),
-            () -> showGrid.setItems(showService.findAllWithRelationships()));
+    Long universeId = universeContextService.getCurrentUniverseId();
+    universeRepository
+        .findById(universeId)
+        .ifPresent(u -> showGrid.setItems(showService.getShowsByUniverse(u)));
   }
 
   private void openGenerateArtDialog(final ShowTemplate template) {

--- a/src/main/java/com/github/javydreamercsw/management/ui/view/title/TitleListView.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/view/title/TitleListView.java
@@ -20,6 +20,7 @@ import com.github.javydreamercsw.base.ai.image.ImageStorageService;
 import com.github.javydreamercsw.base.security.SecurityUtils;
 import com.github.javydreamercsw.base.ui.component.ViewToolbar;
 import com.github.javydreamercsw.management.domain.title.Title;
+import com.github.javydreamercsw.management.domain.universe.UniverseRepository;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.service.ranking.TierRecalculationService;
@@ -66,6 +67,7 @@ public class TitleListView extends Main {
   private final SecurityUtils securityUtils;
   private final ImageStorageService imageStorageService;
   private final UniverseContextService universeContextService;
+  private final UniverseRepository universeRepository;
   public final Grid<Title> grid = new Grid<>(Title.class, false);
 
   public TitleListView(
@@ -75,7 +77,8 @@ public class TitleListView extends Main {
       @NonNull final TierRecalculationService tierRecalculationService,
       @NonNull final SecurityUtils securityUtils,
       @NonNull final ImageStorageService imageStorageService,
-      @NonNull final UniverseContextService universeContextService) {
+      @NonNull final UniverseContextService universeContextService,
+      @NonNull final UniverseRepository universeRepository) {
     this.titleService = titleService;
     this.wrestlerService = wrestlerService;
     this.wrestlerRepository = wrestlerRepository;
@@ -83,6 +86,7 @@ public class TitleListView extends Main {
     this.securityUtils = securityUtils;
     this.imageStorageService = imageStorageService;
     this.universeContextService = universeContextService;
+    this.universeRepository = universeRepository;
 
     addClassNames(
         LumoUtility.BoxSizing.BORDER,
@@ -198,11 +202,10 @@ public class TitleListView extends Main {
   }
 
   public void refreshGrid() {
-    universeContextService
-        .getCurrentUniverse()
-        .ifPresentOrElse(
-            u -> grid.setItems(titleService.findByUniverse(u)),
-            () -> grid.setItems(titleService.findAll()));
+    Long universeId = universeContextService.getCurrentUniverseId();
+    universeRepository
+        .findById(universeId)
+        .ifPresent(u -> grid.setItems(titleService.findByUniverse(u)));
   }
 
   TitleFormDialog openCreateDialog() {

--- a/src/test/java/com/github/javydreamercsw/management/ui/view/title/TitleListViewTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/ui/view/title/TitleListViewTest.java
@@ -31,6 +31,7 @@ import com.github.javydreamercsw.base.domain.wrestler.WrestlerTier;
 import com.github.javydreamercsw.base.security.SecurityUtils;
 import com.github.javydreamercsw.management.domain.title.Title;
 import com.github.javydreamercsw.management.domain.universe.Universe;
+import com.github.javydreamercsw.management.domain.universe.UniverseRepository;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
@@ -67,6 +68,7 @@ class TitleListViewTest extends AbstractViewTest {
   @Mock private TierRecalculationService tierRecalculationService;
   @Mock private ImageStorageService imageStorageService;
   @Mock private UniverseContextService universeContextService;
+  @Mock private UniverseRepository universeRepository;
 
   private TitleListView titleListView;
   private Title testTitle;
@@ -144,7 +146,9 @@ class TitleListViewTest extends AbstractViewTest {
     when(securityUtils.canEdit()).thenReturn(true);
     when(securityUtils.canDelete()).thenReturn(true);
 
-    when(universeContextService.getCurrentUniverse()).thenReturn(java.util.Optional.empty());
+    when(universeContextService.getCurrentUniverseId()).thenReturn(1L);
+    when(universeRepository.findById(1L)).thenReturn(Optional.of(universe));
+    when(titleService.findByUniverse(universe)).thenReturn(List.of(testTitle));
 
     titleListView =
         new TitleListView(
@@ -154,7 +158,8 @@ class TitleListViewTest extends AbstractViewTest {
             tierRecalculationService,
             securityUtils,
             imageStorageService,
-            universeContextService);
+            universeContextService,
+            universeRepository);
   }
 
   @Test
@@ -198,7 +203,7 @@ class TitleListViewTest extends AbstractViewTest {
     newTitle.awardTitleTo(new ArrayList<>(List.of(otherWrestler)), Instant.now());
 
     when(titleService.save(any(Title.class))).thenReturn(newTitle);
-    when(titleService.findAll()).thenReturn(List.of(testTitle, newTitle));
+    when(titleService.findByUniverse(any())).thenReturn(List.of(testTitle, newTitle));
 
     saveButton.click();
     titleListView.refreshGrid();
@@ -245,7 +250,7 @@ class TitleListViewTest extends AbstractViewTest {
     updatedTitle.awardTitleTo(new ArrayList<>(List.of(otherWrestler)), Instant.now());
 
     when(titleService.save(any(Title.class))).thenReturn(updatedTitle);
-    when(titleService.findAll()).thenReturn(List.of(updatedTitle));
+    when(titleService.findByUniverse(any())).thenReturn(List.of(updatedTitle));
 
     saveButton.click();
     titleListView.refreshGrid();
@@ -259,7 +264,8 @@ class TitleListViewTest extends AbstractViewTest {
 
   @Test
   void testDeleteTitle() {
-    when(titleService.findAll()).thenReturn(new ArrayList<>()); // Return empty list after deletion
+    when(titleService.findByUniverse(any()))
+        .thenReturn(new ArrayList<>()); // Return empty list after deletion
 
     // Simulate deletion
     titleService.deleteTitle(testTitle.getId());


### PR DESCRIPTION
## Summary
- `ShowListView` and `TitleListView` were falling back to showing all entities
  when no universe was selected in the session, instead of defaulting to universe ID=1
- `LeagueListView` skipped the universe filter entirely when `getCurrentUniverse()`
  returned empty
- All three now use `getCurrentUniverseId()` (which already defaults to 1L),
  matching the existing `FactionListView` pattern
- `TitleListView` gains a `UniverseRepository` dependency to look up the Universe
  entity by ID for the service call

## Test plan
- [ ] Verify switching the universe selector updates Show, Faction, Title, and League list views
- [ ] Verify no cross-universe entities appear when a universe is selected
- [ ] Verify views default to universe ID=1 when no universe has been explicitly selected
- [ ] Unit tests updated and passing (TitleListViewTest updated to mock findByUniverse instead of findAll)