### PR TITLE
feat(ATW-38r): enforce per-universe wrestler exclusions in findAllFiltered

### DIFF
--- a/src/main/java/com/github/javydreamercsw/management/domain/universe/UniverseWrestlerExclusionRepository.java
+++ b/src/main/java/com/github/javydreamercsw/management/domain/universe/UniverseWrestlerExclusionRepository.java
@@ -18,7 +18,10 @@ package com.github.javydreamercsw.management.domain.universe;
 
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UniverseWrestlerExclusionRepository
     extends JpaRepository<UniverseWrestlerExclusion, Long> {
@@ -28,4 +31,11 @@ public interface UniverseWrestlerExclusionRepository
   boolean existsByUniverseAndWrestler(Universe universe, Wrestler wrestler);
 
   void deleteByUniverseAndWrestler(Universe universe, Wrestler wrestler);
+
+  /**
+   * Returns the IDs of wrestlers excluded from the given universe. Using an ID-only projection
+   * avoids loading full Wrestler entities and keeps this query cheap.
+   */
+  @Query("SELECT e.wrestler.id FROM UniverseWrestlerExclusion e WHERE e.universe.id = :universeId")
+  Set<Long> findExcludedWrestlerIdsByUniverseId(@Param("universeId") Long universeId);
 }

--- a/src/main/java/com/github/javydreamercsw/management/service/wrestler/WrestlerService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/wrestler/WrestlerService.java
@@ -28,6 +28,7 @@ import com.github.javydreamercsw.management.domain.campaign.AlignmentType;
 import com.github.javydreamercsw.management.domain.campaign.WrestlerAlignment;
 import com.github.javydreamercsw.management.domain.campaign.WrestlerAlignmentRepository;
 import com.github.javydreamercsw.management.domain.universe.Universe;
+import com.github.javydreamercsw.management.domain.universe.UniverseWrestlerExclusionRepository;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerDTO;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
@@ -75,6 +76,7 @@ public class WrestlerService {
       universeRepository;
   private final WrestlerAlignmentRepository wrestlerAlignmentRepository;
   private final UniverseContextService universeContextService;
+  private final UniverseWrestlerExclusionRepository wrestlerExclusionRepository;
 
   @Autowired
   public WrestlerService(
@@ -93,7 +95,8 @@ public class WrestlerService {
       final com.github.javydreamercsw.management.domain.universe.UniverseRepository
           universeRepository,
       final WrestlerAlignmentRepository wrestlerAlignmentRepository,
-      final UniverseContextService universeContextService) {
+      final UniverseContextService universeContextService,
+      final UniverseWrestlerExclusionRepository wrestlerExclusionRepository) {
     this.wrestlerRepository = wrestlerRepository;
     this.wrestlerStateRepository = wrestlerStateRepository;
     this.tierBoundaryRepository = tierBoundaryRepository;
@@ -108,6 +111,7 @@ public class WrestlerService {
     this.universeRepository = universeRepository;
     this.wrestlerAlignmentRepository = wrestlerAlignmentRepository;
     this.universeContextService = universeContextService;
+    this.wrestlerExclusionRepository = wrestlerExclusionRepository;
   }
 
   @Transactional
@@ -238,11 +242,21 @@ public class WrestlerService {
     final Long finalUniverseId =
         universeId != null ? universeId : universeContextService.getCurrentUniverseId();
 
+    // Load excluded wrestler IDs for this universe once, outside the stream.
+    // includedWrestlers acts as a force-include override (e.g. already-assigned segment
+    // participants) that bypasses both the exclusion list and all other filters.
+    final Set<Long> excludedIds =
+        wrestlerExclusionRepository.findExcludedWrestlerIdsByUniverseId(finalUniverseId);
+
     return wrestlerRepository.findAllByActiveTrue().stream()
         .filter(
             w -> {
               if (includedWrestlers != null && includedWrestlers.contains(w)) {
                 return true;
+              }
+
+              if (excludedIds.contains(w.getId())) {
+                return false;
               }
 
               boolean matchesAlignment = alignmentType == null;

--- a/src/test/java/com/github/javydreamercsw/management/service/wrestler/WrestlerServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/wrestler/WrestlerServiceTest.java
@@ -27,6 +27,7 @@ import com.github.javydreamercsw.management.domain.campaign.AlignmentType;
 import com.github.javydreamercsw.management.domain.campaign.WrestlerAlignment;
 import com.github.javydreamercsw.management.domain.universe.Universe;
 import com.github.javydreamercsw.management.domain.universe.UniverseRepository;
+import com.github.javydreamercsw.management.domain.universe.UniverseWrestlerExclusionRepository;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
@@ -40,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,6 +74,7 @@ class WrestlerServiceTest {
   @Mock private com.github.javydreamercsw.management.service.segment.SegmentService segmentService;
   @Mock private com.github.javydreamercsw.management.service.title.TitleService titleService;
   @Mock private com.github.javydreamercsw.base.security.SecurityUtils securityUtils;
+  @Mock private UniverseWrestlerExclusionRepository wrestlerExclusionRepository;
 
   @InjectMocks private WrestlerService wrestlerService;
 
@@ -86,6 +89,11 @@ class WrestlerServiceTest {
   public void setUp() {
     when(expansionService.getEnabledExpansionCodes())
         .thenReturn(Collections.singletonList("BASE_GAME"));
+
+    // Default: no wrestlers excluded from any universe
+    lenient()
+        .when(wrestlerExclusionRepository.findExcludedWrestlerIdsByUniverseId(anyLong()))
+        .thenReturn(Set.of());
 
     Universe universe = Universe.builder().name("Default Universe").build();
     universe.setId(1L);
@@ -257,6 +265,42 @@ class WrestlerServiceTest {
         wrestlerService.findAllFiltered(null, Gender.FEMALE, 1L, (String) null, null);
     assertEquals(1, femaleWrestlers.size());
     assertEquals("Active NPC", femaleWrestlers.get(0).getName());
+  }
+
+  @Test
+  void testFindAllFiltered_excludedWrestlersAreHidden() {
+    when(wrestlerRepository.findAllByActiveTrue())
+        .thenReturn(wrestlers.stream().filter(Wrestler::getActive).toList());
+
+    // Exclude wrestler with id=1 ("Active Player") from universe 1
+    when(wrestlerExclusionRepository.findExcludedWrestlerIdsByUniverseId(1L))
+        .thenReturn(Set.of(1L));
+
+    List<Wrestler> result = wrestlerService.findAllFiltered(null, null, 1L, (String) null, null);
+
+    // Active wrestlers: ids 1, 2, 5 — with id=1 excluded → 2 and 5 remain
+    assertEquals(2, result.size());
+    result.forEach(
+        w -> assertEquals(false, w.getId().equals(1L), "Excluded wrestler must not appear"));
+  }
+
+  @Test
+  void testFindAllFiltered_includedWrestlersBypassesExclusion() {
+    when(wrestlerRepository.findAllByActiveTrue())
+        .thenReturn(wrestlers.stream().filter(Wrestler::getActive).toList());
+
+    // Exclude wrestler with id=1 from universe 1
+    when(wrestlerExclusionRepository.findExcludedWrestlerIdsByUniverseId(1L))
+        .thenReturn(Set.of(1L));
+
+    // But force-include that same wrestler (already assigned to a segment)
+    Wrestler excludedButIncluded =
+        wrestlers.stream().filter(w -> w.getId().equals(1L)).findFirst().orElseThrow();
+    List<Wrestler> result =
+        wrestlerService.findAllFiltered(null, null, 1L, (String) null, Set.of(excludedButIncluded));
+
+    // The excluded wrestler is force-included — all 3 active appear
+    assertEquals(3, result.size());
   }
 
   @Test


### PR DESCRIPTION
Add findExcludedWrestlerIdsByUniverseId JPQL query to UniverseWrestlerExclusionRepository for a cheap ID-only projection. Wire it into WrestlerService.findAllFiltered so all wrestler pickers (ShowDetailView, EditSegmentDialog, etc.) automatically respect universe-level exclusions. The includedWrestlers override still bypasses exclusions for already-assigned segment participants.

Admin UI and WrestlerListView filtering were already in place.