### PR TITLE
feat(ATW-46y): wire per-universe expansion settings to runtime content filtering

### DIFF
--- a/src/main/java/com/github/javydreamercsw/management/service/faction/FactionService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/faction/FactionService.java
@@ -27,9 +27,12 @@ import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerStateRepository;
 import com.github.javydreamercsw.management.service.expansion.ExpansionService;
+import com.github.javydreamercsw.management.service.universe.UniverseContextService;
+import com.github.javydreamercsw.management.service.universe.UniverseSettingsService;
 import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -53,6 +56,8 @@ public class FactionService {
   private final UniverseRepository universeRepository;
   private final WrestlerStateRepository wrestlerStateRepository;
   private final ExpansionService expansionService;
+  private final UniverseContextService universeContextService;
+  private final UniverseSettingsService universeSettingsService;
   private final Clock clock;
   private final DefaultImageService imageService;
 
@@ -63,6 +68,8 @@ public class FactionService {
       final UniverseRepository universeRepository,
       final WrestlerStateRepository wrestlerStateRepository,
       final ExpansionService expansionService,
+      final UniverseContextService universeContextService,
+      final UniverseSettingsService universeSettingsService,
       final Clock clock,
       final DefaultImageService imageService) {
     this.factionRepository = factionRepository;
@@ -70,15 +77,24 @@ public class FactionService {
     this.universeRepository = universeRepository;
     this.wrestlerStateRepository = wrestlerStateRepository;
     this.expansionService = expansionService;
+    this.universeContextService = universeContextService;
+    this.universeSettingsService = universeSettingsService;
     this.clock = clock;
     this.imageService = imageService;
+  }
+
+  private Set<String> enabledExpansionCodes() {
+    return universeContextService
+        .getCurrentUniverse()
+        .map(universeSettingsService::getEnabledExpansionCodesForUniverse)
+        .orElseGet(() -> new java.util.HashSet<>(expansionService.getEnabledExpansionCodes()));
   }
 
   /** Get all factions. */
   @Transactional(readOnly = true)
   @PreAuthorize("isAuthenticated()")
   public List<Faction> findAll() {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
     return factionRepository.findAll().stream()
         .filter(
             faction ->
@@ -101,7 +117,8 @@ public class FactionService {
   @PreAuthorize("isAuthenticated()")
   public List<Faction> findAllByUniverse(@NonNull final Long universeId) {
     Universe universe = universeRepository.findById(universeId).orElseThrow();
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions =
+        universeSettingsService.getEnabledExpansionCodesForUniverse(universe);
     return factionRepository.findByUniverseWithLeaderAndManager(universe).stream()
         .filter(
             faction ->
@@ -123,7 +140,7 @@ public class FactionService {
   @Transactional(readOnly = true)
   @PreAuthorize("isAuthenticated()")
   public Page<Faction> getAllFactions(final Pageable pageable) {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
 
     List<Faction> allFiltered =
         factionRepository.findAll().stream()
@@ -185,7 +202,7 @@ public class FactionService {
   @Transactional(readOnly = true)
   @PreAuthorize("isAuthenticated()")
   public List<Faction> getActiveFactions() {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
     return factionRepository.findByIsActiveTrue().stream()
         .filter(
             faction ->

--- a/src/main/java/com/github/javydreamercsw/management/service/npc/NpcService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/npc/NpcService.java
@@ -24,8 +24,12 @@ import com.github.javydreamercsw.management.domain.npc.Npc;
 import com.github.javydreamercsw.management.domain.npc.NpcRepository;
 import com.github.javydreamercsw.management.service.expansion.ExpansionService;
 import com.github.javydreamercsw.management.service.expansion.ExpansionToggledEvent;
+import com.github.javydreamercsw.management.service.universe.UniverseContextService;
+import com.github.javydreamercsw.management.service.universe.UniverseExpansionToggledEvent;
+import com.github.javydreamercsw.management.service.universe.UniverseSettingsService;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,16 +48,29 @@ public class NpcService {
 
   private final NpcRepository npcRepository;
   private final ExpansionService expansionService;
+  private final UniverseContextService universeContextService;
+  private final UniverseSettingsService universeSettingsService;
   private final DefaultImageService imageService;
 
   @Autowired
   public NpcService(
       final NpcRepository npcRepository,
       final ExpansionService expansionService,
+      final UniverseContextService universeContextService,
+      final UniverseSettingsService universeSettingsService,
       final DefaultImageService imageService) {
     this.npcRepository = npcRepository;
     this.expansionService = expansionService;
+    this.universeContextService = universeContextService;
+    this.universeSettingsService = universeSettingsService;
     this.imageService = imageService;
+  }
+
+  private Set<String> enabledExpansionCodes() {
+    return universeContextService
+        .getCurrentUniverse()
+        .map(universeSettingsService::getEnabledExpansionCodesForUniverse)
+        .orElseGet(() -> new java.util.HashSet<>(expansionService.getEnabledExpansionCodes()));
   }
 
   public static final String ATTRIBUTE_AWARENESS = "awareness";
@@ -84,14 +101,14 @@ public class NpcService {
   }
 
   public List<Npc> findAllByType(final String npcType) {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
     return npcRepository.findAllByNpcType(npcType).stream()
         .filter(npc -> enabledExpansions.contains(npc.getExpansionCode()))
         .collect(Collectors.toList());
   }
 
   public List<Npc> findAllIncludingInactive() {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
     return npcRepository.findAll().stream()
         .filter(npc -> enabledExpansions.contains(npc.getExpansionCode()))
         .collect(Collectors.toList());
@@ -99,7 +116,7 @@ public class NpcService {
 
   @Cacheable(value = NPCS_CACHE)
   public List<Npc> findAll() {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
     return npcRepository.findAll().stream()
         .filter(npc -> enabledExpansions.contains(npc.getExpansionCode()))
         .collect(Collectors.toList());
@@ -127,6 +144,15 @@ public class NpcService {
   @CacheEvict(value = NPCS_CACHE, allEntries = true)
   public void onExpansionToggled(final ExpansionToggledEvent event) {
     log.info("Expansion '{}' toggled, evicting NPC cache.", event.getExpansionCode());
+  }
+
+  @EventListener
+  @CacheEvict(value = NPCS_CACHE, allEntries = true)
+  public void onUniverseExpansionToggled(final UniverseExpansionToggledEvent event) {
+    log.info(
+        "Universe {} expansion '{}' toggled, evicting NPC cache.",
+        event.getUniverseId(),
+        event.getExpansionCode());
   }
 
   public void delete(final Npc npc) {

--- a/src/main/java/com/github/javydreamercsw/management/service/team/TeamService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/team/TeamService.java
@@ -27,8 +27,11 @@ import com.github.javydreamercsw.management.domain.team.TeamStatus;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.service.expansion.ExpansionService;
+import com.github.javydreamercsw.management.service.universe.UniverseContextService;
+import com.github.javydreamercsw.management.service.universe.UniverseSettingsService;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +54,16 @@ public class TeamService {
   @Autowired private FactionRepository factionRepository;
   @Autowired private NpcRepository npcRepository;
   @Autowired private ExpansionService expansionService;
+  @Autowired private UniverseContextService universeContextService;
+  @Autowired private UniverseSettingsService universeSettingsService;
   @Autowired private DefaultImageService imageService;
+
+  private Set<String> enabledExpansionCodes() {
+    return universeContextService
+        .getCurrentUniverse()
+        .map(universeSettingsService::getEnabledExpansionCodesForUniverse)
+        .orElseGet(() -> new java.util.HashSet<>(expansionService.getEnabledExpansionCodes()));
+  }
 
   // ==================== CRUD OPERATIONS ====================
 
@@ -59,7 +71,7 @@ public class TeamService {
   @Transactional(readOnly = true)
   @PreAuthorize("isAuthenticated()")
   public org.springframework.data.domain.Page<Team> getAllTeams(@NonNull final Pageable pageable) {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
 
     // Fetch all since we need to filter based on member properties not in the Team table directly
     // and then manually paginate.
@@ -100,7 +112,7 @@ public class TeamService {
   @Transactional(readOnly = true)
   @PreAuthorize("isAuthenticated()")
   public long countAllTeams() {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
     return teamRepository.findAll().stream()
         .filter(
             team ->
@@ -285,7 +297,7 @@ public class TeamService {
   @Transactional(readOnly = true)
   @PreAuthorize("isAuthenticated()")
   public List<Team> getActiveTeams() {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
     return teamRepository.findByStatus(TeamStatus.ACTIVE).stream()
         .filter(
             team ->
@@ -312,7 +324,7 @@ public class TeamService {
   @Transactional(readOnly = true)
   @PreAuthorize("isAuthenticated()")
   public List<Team> getTeamsByFaction(final Faction faction) {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
     return teamRepository.findByFaction(faction).stream()
         .filter(
             team ->
@@ -332,7 +344,7 @@ public class TeamService {
   @Transactional(readOnly = true)
   @PreAuthorize("isAuthenticated()")
   public List<Team> getTeamsByWrestler(final Wrestler wrestler) {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
     return teamRepository.findByWrestler(wrestler).stream()
         .filter(
             team ->
@@ -352,7 +364,7 @@ public class TeamService {
   @Transactional(readOnly = true)
   @PreAuthorize("isAuthenticated()")
   public List<Team> getActiveTeamsByWrestler(final Wrestler wrestler) {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
     return teamRepository.findByWrestlerAndStatus(wrestler, TeamStatus.ACTIVE).stream()
         .filter(
             team ->
@@ -372,7 +384,7 @@ public class TeamService {
   @Transactional(readOnly = true)
   @PreAuthorize("isAuthenticated()")
   public Optional<Team> findTeamByWrestlers(final Wrestler wrestler1, final Wrestler wrestler2) {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
     return teamRepository
         .findByBothWrestlers(wrestler1, wrestler2)
         .filter(
@@ -394,7 +406,7 @@ public class TeamService {
   @PreAuthorize("isAuthenticated()")
   public Optional<Team> findActiveTeamByWrestlers(
       final Wrestler wrestler1, final Wrestler wrestler2) {
-    List<String> enabledExpansions = expansionService.getEnabledExpansionCodes();
+    Set<String> enabledExpansions = enabledExpansionCodes();
     return teamRepository
         .findActiveTeamByBothWrestlers(wrestler1, wrestler2)
         .filter(

--- a/src/main/java/com/github/javydreamercsw/management/service/universe/UniverseExpansionToggledEvent.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/universe/UniverseExpansionToggledEvent.java
@@ -1,0 +1,38 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.universe;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class UniverseExpansionToggledEvent extends ApplicationEvent {
+  private final Long universeId;
+  private final String expansionCode;
+  private final boolean enabled;
+
+  public UniverseExpansionToggledEvent(
+      final Object source,
+      final Long universeId,
+      final String expansionCode,
+      final boolean enabled) {
+    super(source);
+    this.universeId = universeId;
+    this.expansionCode = expansionCode;
+    this.enabled = enabled;
+  }
+}

--- a/src/main/java/com/github/javydreamercsw/management/service/universe/UniverseSettingsService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/universe/UniverseSettingsService.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +41,16 @@ public class UniverseSettingsService {
   private final UniverseExpansionSettingRepository expansionSettingRepository;
   private final UniverseWrestlerExclusionRepository wrestlerExclusionRepository;
   private final ExpansionService expansionService;
+  private final ApplicationEventPublisher eventPublisher;
+
+  /** Returns the set of expansion codes enabled for a universe (falling back to global). */
+  @PreAuthorize("isAuthenticated()")
+  public Set<String> getEnabledExpansionCodesForUniverse(@NonNull final Universe universe) {
+    return expansionService.getExpansions().stream()
+        .filter(e -> isExpansionEnabledForUniverse(universe, e.getCode()))
+        .map(Expansion::getCode)
+        .collect(Collectors.toSet());
+  }
 
   /** Returns all expansions with their per-universe enabled state (falling back to global). */
   @PreAuthorize("isAuthenticated()")
@@ -81,6 +92,8 @@ public class UniverseSettingsService {
                 });
     setting.setEnabled(enabled);
     expansionSettingRepository.save(setting);
+    eventPublisher.publishEvent(
+        new UniverseExpansionToggledEvent(this, universe.getId(), expansionCode, enabled));
   }
 
   /** Removes the per-universe override, reverting to the global setting. */

--- a/src/main/java/com/github/javydreamercsw/management/ui/view/wrestler/WrestlerListView.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/view/wrestler/WrestlerListView.java
@@ -177,7 +177,12 @@ public class WrestlerListView extends Main {
                 return "";
               }
               String expansionCode = state.getManager().getExpansionCode();
-              if (!expansionService.getEnabledExpansionCodes().contains(expansionCode)) {
+              Set<String> enabled =
+                  universeContextService
+                      .getCurrentUniverse()
+                      .map(universeSettingsService::getEnabledExpansionCodesForUniverse)
+                      .orElseGet(() -> new HashSet<>(expansionService.getEnabledExpansionCodes()));
+              if (!enabled.contains(expansionCode)) {
                 return "";
               }
               return state.getManager().getName();
@@ -263,7 +268,11 @@ public class WrestlerListView extends Main {
             .map(Wrestler::getId)
             .collect(Collectors.toSet());
 
-    Set<String> enabledCodes = new HashSet<>(expansionService.getEnabledExpansionCodes());
+    Set<String> enabledCodes =
+        universeContextService
+            .getCurrentUniverse()
+            .map(universeSettingsService::getEnabledExpansionCodesForUniverse)
+            .orElseGet(() -> new HashSet<>(expansionService.getEnabledExpansionCodes()));
     Set<Long> excludedIds =
         universeContextService
             .getCurrentUniverse()

--- a/src/test/java/com/github/javydreamercsw/management/service/faction/FactionServiceIntegrationTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/faction/FactionServiceIntegrationTest.java
@@ -26,6 +26,7 @@ import com.github.javydreamercsw.management.domain.universe.UniverseRepository;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.service.expansion.ExpansionService;
+import com.github.javydreamercsw.management.service.universe.UniverseContextService;
 import com.github.javydreamercsw.management.service.wrestler.WrestlerService;
 import com.github.javydreamercsw.management.test.AbstractMockUserIntegrationTest;
 import java.util.Arrays;
@@ -49,6 +50,7 @@ class FactionServiceIntegrationTest extends AbstractMockUserIntegrationTest {
   @Autowired private UniverseRepository universeRepository;
 
   @MockitoSpyBean private ExpansionService expansionService;
+  @MockitoSpyBean private UniverseContextService universeContextService;
   private Faction testFaction;
   private Wrestler testWrestler1;
   private Wrestler testWrestler2;
@@ -59,6 +61,8 @@ class FactionServiceIntegrationTest extends AbstractMockUserIntegrationTest {
     // Default mock behavior
     when(expansionService.getEnabledExpansionCodes())
         .thenReturn(Arrays.asList("BASE_GAME", "EXTREME"));
+    // Ensure no universe context is active so tests use the global expansionService mock
+    when(universeContextService.getCurrentUniverse()).thenReturn(Optional.empty());
 
     // Create test wrestlers with all required fields
     testWrestler1 = wrestlerService.createWrestler("John Cena", true, null);

--- a/src/test/java/com/github/javydreamercsw/management/service/faction/FactionServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/faction/FactionServiceTest.java
@@ -34,6 +34,8 @@ import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerStateRepository;
 import com.github.javydreamercsw.management.service.expansion.ExpansionService;
+import com.github.javydreamercsw.management.service.universe.UniverseContextService;
+import com.github.javydreamercsw.management.service.universe.UniverseSettingsService;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -62,6 +64,8 @@ class FactionServiceTest {
   @Mock private UniverseRepository universeRepository;
   @Mock private WrestlerStateRepository wrestlerStateRepository;
   @Mock private ExpansionService expansionService;
+  @Mock private UniverseContextService universeContextService;
+  @Mock private UniverseSettingsService universeSettingsService;
   @Mock private Clock clock;
   @Mock private DefaultImageService imageService;
 
@@ -80,6 +84,9 @@ class FactionServiceTest {
     when(clock.instant()).thenReturn(FIXED_INSTANT);
     when(clock.getZone()).thenReturn(ZoneId.of("UTC"));
     when(expansionService.getEnabledExpansionCodes()).thenReturn(List.of(BASE_EXPANSION));
+    when(universeContextService.getCurrentUniverse()).thenReturn(Optional.empty());
+    when(universeSettingsService.getEnabledExpansionCodesForUniverse(any()))
+        .thenReturn(Set.of(BASE_EXPANSION));
 
     universe = Universe.builder().build();
     universe.setId(1L);

--- a/src/test/java/com/github/javydreamercsw/management/service/npc/NpcServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/npc/NpcServiceTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.*;
 import com.github.javydreamercsw.management.domain.npc.Npc;
 import com.github.javydreamercsw.management.domain.npc.NpcRepository;
 import com.github.javydreamercsw.management.service.expansion.ExpansionService;
+import com.github.javydreamercsw.management.service.universe.UniverseContextService;
+import com.github.javydreamercsw.management.service.universe.UniverseSettingsService;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -41,6 +43,8 @@ class NpcServiceTest {
 
   @Mock private NpcRepository npcRepository;
   @Mock private ExpansionService expansionService;
+  @Mock private UniverseContextService universeContextService;
+  @Mock private UniverseSettingsService universeSettingsService;
   @Mock private com.github.javydreamercsw.base.image.DefaultImageService imageService;
 
   @InjectMocks private NpcService npcService;
@@ -55,6 +59,7 @@ class NpcServiceTest {
     npc.setNpcType("Referee");
     npc.setExpansionCode("BASE_GAME");
 
+    when(universeContextService.getCurrentUniverse()).thenReturn(Optional.empty());
     when(expansionService.getEnabledExpansionCodes()).thenReturn(Arrays.asList("BASE_GAME"));
   }
 

--- a/src/test/java/com/github/javydreamercsw/management/service/team/TeamServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/team/TeamServiceTest.java
@@ -26,6 +26,7 @@ import com.github.javydreamercsw.management.domain.team.TeamStatus;
 import com.github.javydreamercsw.management.domain.universe.Universe;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.service.expansion.ExpansionService;
+import com.github.javydreamercsw.management.service.universe.UniverseContextService;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -52,6 +53,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 class TeamServiceTest extends ManagementIntegrationTest {
 
   @MockitoSpyBean private ExpansionService expansionService;
+  @MockitoSpyBean private UniverseContextService universeContextService;
   private Wrestler wrestler1;
   private Wrestler wrestler2;
   private Wrestler wrestler3;
@@ -93,6 +95,8 @@ class TeamServiceTest extends ManagementIntegrationTest {
     // Default mock behavior
     when(expansionService.getEnabledExpansionCodes())
         .thenReturn(Arrays.asList("BASE_GAME", "EXTREME"));
+    // Ensure no universe context is active so tests use the global expansionService mock
+    when(universeContextService.getCurrentUniverse()).thenReturn(Optional.empty());
   }
 
   @Test


### PR DESCRIPTION
Per-universe expansion overrides were stored in UniverseExpansionSetting but never consulted at runtime — all filtering fell through to the global ExpansionService. This wires UniverseSettingsService into FactionService, TeamService, NpcService, and WrestlerListView so enabled-expansion checks use the active universe's overrides, falling back to global when no universe context is set.

Also adds UniverseExpansionToggledEvent published when a per-universe toggle is saved, so the NPC cache evicts correctly on universe-level changes in addition to global ones.