### PR TITLE
feat(ATW-aq5): wire CampaignEffectContext stubs to CampaignState and featureData

### DIFF
--- a/src/main/java/com/github/javydreamercsw/management/domain/wrestler/Wrestler.java
+++ b/src/main/java/com/github/javydreamercsw/management/domain/wrestler/Wrestler.java
@@ -266,13 +266,15 @@ public class Wrestler extends AbstractSyncableEntity<Long> {
   @JsonIgnore
   public Integer getEffectiveStartingStamina() {
     WrestlerAlignment alignment = getAlignment();
-    int bonus =
-        alignment != null
-                && alignment.getCampaign() != null
-                && alignment.getCampaign().getState() != null
-            ? alignment.getCampaign().getState().getCampaignStaminaBonus()
-            : 0;
-    return startingStamina + bonus;
+    int bonus = 0;
+    int penalty = 0;
+    if (alignment != null
+        && alignment.getCampaign() != null
+        && alignment.getCampaign().getState() != null) {
+      bonus = alignment.getCampaign().getState().getCampaignStaminaBonus();
+      penalty = alignment.getCampaign().getState().getStaminaPenalty();
+    }
+    return Math.max(1, startingStamina + bonus - penalty);
   }
 
   @JsonIgnore

--- a/src/main/java/com/github/javydreamercsw/management/service/campaign/BackstageActionService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/campaign/BackstageActionService.java
@@ -16,6 +16,8 @@
 */
 package com.github.javydreamercsw.management.service.campaign;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javydreamercsw.management.domain.campaign.AlignmentType;
 import com.github.javydreamercsw.management.domain.campaign.BackstageActionHistory;
 import com.github.javydreamercsw.management.domain.campaign.BackstageActionHistoryRepository;
@@ -33,6 +35,7 @@ import com.github.javydreamercsw.utils.DiceBag;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -51,6 +54,7 @@ public class BackstageActionService {
   private final CampaignService campaignService;
   private final SegmentRuleRepository segmentRuleRepository;
   private final WrestlerService wrestlerService;
+  private final ObjectMapper objectMapper;
   @Getter private final BackstageEncounterService backstageEncounterService;
 
   public BackstageActionService(
@@ -60,6 +64,7 @@ public class BackstageActionService {
       @Lazy final CampaignService campaignService,
       final SegmentRuleRepository segmentRuleRepository,
       final WrestlerService wrestlerService,
+      final ObjectMapper objectMapper,
       final BackstageEncounterService backstageEncounterService) {
     this.campaignStateRepository = campaignStateRepository;
     this.actionHistoryRepository = actionHistoryRepository;
@@ -67,6 +72,7 @@ public class BackstageActionService {
     this.campaignService = campaignService;
     this.segmentRuleRepository = segmentRuleRepository;
     this.wrestlerService = wrestlerService;
+    this.objectMapper = objectMapper;
     this.backstageEncounterService = backstageEncounterService;
   }
 
@@ -116,8 +122,21 @@ public class BackstageActionService {
       }
     }
 
-    java.util.List<Integer> rolls = rollDice(diceSides);
+    // Apply backstage dice bonus from script effects (ATW-ta7)
+    int effectiveDice =
+        diceSides + consumeFeatureInt(state, CampaignEffectContext.KEY_BACKSTAGE_DICE_BONUS);
+    java.util.List<Integer> rolls = rollDice(effectiveDice);
     int successes = (int) rolls.stream().filter(r -> r >= 4).count();
+
+    // Apply player roll modifier from script effects (ATW-t8q)
+    int rollModifier = consumeFeatureInt(state, CampaignEffectContext.KEY_PLAYER_ROLL_MODIFIER);
+    if (rollModifier != 0) {
+      successes = Math.max(0, successes + rollModifier);
+      log.debug(
+          "[Backstage] Applied playerRollModifier={} → adjusted successes={}",
+          rollModifier,
+          successes);
+    }
     String outcomeDescription = "";
     boolean isSuccess = successes > 0;
 
@@ -246,6 +265,32 @@ public class BackstageActionService {
     actionHistoryRepository.save(history);
 
     return new ActionOutcome(successes, outcomeDescription);
+  }
+
+  /**
+   * Reads an int value from the campaign state's featureData by key, then clears it (one-shot
+   * consumption). Returns 0 if the key is absent or featureData is unparseable.
+   */
+  private int consumeFeatureInt(final CampaignState state, final String key) {
+    if (state.getFeatureData() == null) {
+      return 0;
+    }
+    try {
+      Map<String, Object> data =
+          objectMapper.readValue(
+              state.getFeatureData(), new TypeReference<Map<String, Object>>() {});
+      Object value = data.remove(key);
+      if (value == null) {
+        return 0;
+      }
+      int result = ((Number) value).intValue();
+      state.setFeatureData(objectMapper.writeValueAsString(data));
+      campaignStateRepository.save(state);
+      return result;
+    } catch (Exception e) {
+      log.warn("Failed to consume featureData key '{}' in BackstageActionService", key, e);
+      return 0;
+    }
   }
 
   /**

--- a/src/main/java/com/github/javydreamercsw/management/service/campaign/CampaignEffectContext.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/campaign/CampaignEffectContext.java
@@ -16,8 +16,13 @@
 */
 package com.github.javydreamercsw.management.service.campaign;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javydreamercsw.management.domain.campaign.Campaign;
-import lombok.RequiredArgsConstructor;
+import com.github.javydreamercsw.management.domain.campaign.CampaignState;
+import com.github.javydreamercsw.management.domain.campaign.CampaignStateRepository;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -25,84 +30,193 @@ import lombok.extern.slf4j.Slf4j;
  * manipulate campaign state, wrestler stats, and match flow.
  */
 @Slf4j
-@RequiredArgsConstructor
 public class CampaignEffectContext {
 
+  // featureData keys consumed by sub-issues (match engine wiring)
+  public static final String KEY_INITIATIVE_GRANTED = "initiativeGranted";
+  public static final String KEY_PENDING_PIN_ATTEMPT = "pendingPinAttempt";
+  public static final String KEY_BREAK_PIN_GRANTED = "breakPinGranted";
+  public static final String KEY_ATTACK_NEGATED = "attackNegated";
+  public static final String KEY_PLAYER_ROLL_MODIFIER = "playerRollModifier";
+  public static final String KEY_OPPONENT_ROLL_MODIFIER = "opponentRollModifier";
+  public static final String KEY_BACKSTAGE_DICE_BONUS = "backstageDiceBonus";
+  public static final String KEY_ATTRIBUTE_MODIFIER_PREFIX = "attributeModifier_";
+
   private final Campaign campaign;
+  private final CampaignStateRepository stateRepository;
+  private final ObjectMapper objectMapper;
+
+  public CampaignEffectContext(
+      final Campaign campaign,
+      final CampaignStateRepository stateRepository,
+      final ObjectMapper objectMapper) {
+    this.campaign = campaign;
+    this.stateRepository = stateRepository;
+    this.objectMapper = objectMapper;
+  }
 
   // ==================== Resource Management ====================
 
   public void spendStamina(final int amount) {
-    // TODO: Integrate with Match Engine to reduce current stamina
-    log.debug("[Script] Spending {} Stamina", amount);
+    CampaignState state = campaign.getState();
+    state.setStaminaPenalty(state.getStaminaPenalty() + amount);
+    stateRepository.save(state);
+    log.debug(
+        "[Script] Spending {} Stamina. New staminaPenalty={}", amount, state.getStaminaPenalty());
   }
 
   public void gainStamina(final int amount) {
-    // TODO: Integrate with Match Engine to increase current stamina
-    log.debug("[Script] Gaining {} Stamina", amount);
+    CampaignState state = campaign.getState();
+    state.setStaminaPenalty(Math.max(0, state.getStaminaPenalty() - amount));
+    stateRepository.save(state);
+    log.debug(
+        "[Script] Gaining {} Stamina. New staminaPenalty={}", amount, state.getStaminaPenalty());
   }
 
   public void gainHitPoints(final int amount) {
-    // TODO: Integrate with Match Engine to heal
-    log.debug("[Script] Gaining {} HP", amount);
+    CampaignState state = campaign.getState();
+    state.setHealthPenalty(Math.max(0, state.getHealthPenalty() - amount));
+    stateRepository.save(state);
+    log.debug("[Script] Gaining {} HP. New healthPenalty={}", amount, state.getHealthPenalty());
   }
 
   public void damage(final int amount) {
-    // TODO: Integrate with Match Engine to damage opponent
-    log.debug("[Script] Dealing {} Damage to opponent", amount);
+    CampaignState state = campaign.getState();
+    state.setOpponentHealthPenalty(state.getOpponentHealthPenalty() + amount);
+    stateRepository.save(state);
+    log.debug(
+        "[Script] Dealing {} damage to opponent. New opponentHealthPenalty={}",
+        amount,
+        state.getOpponentHealthPenalty());
   }
 
   public void gainMomentum(final int amount) {
-    // TODO: Integrate with Match Engine momentum tracker
-    log.debug("[Script] Gaining {} Momentum", amount);
+    CampaignState state = campaign.getState();
+    state.setMomentumBonus(state.getMomentumBonus() + amount);
+    stateRepository.save(state);
+    log.debug(
+        "[Script] Gaining {} Momentum. New momentumBonus={}", amount, state.getMomentumBonus());
   }
 
   public void drawCard(final int amount) {
-    // TODO: Integrate with Deck/Hand management
-    log.debug("[Script] Drawing {} cards", amount);
+    CampaignState state = campaign.getState();
+    state.setHandSizePenalty(Math.max(0, state.getHandSizePenalty() - amount));
+    stateRepository.save(state);
+    log.debug(
+        "[Script] Drawing {} cards. New handSizePenalty={}", amount, state.getHandSizePenalty());
   }
 
   // ==================== Match Flow Control ====================
 
   public void gainInitiative() {
-    // TODO: Set initiative to player
-    log.debug("[Script] Gaining Initiative");
+    setFeatureFlag(KEY_INITIATIVE_GRANTED, true);
+    log.debug("[Script] Initiative granted to player");
   }
 
   public void pin() {
-    // TODO: Attempt pinfall
-    log.debug("[Script] Attempting Pin");
+    setFeatureFlag(KEY_PENDING_PIN_ATTEMPT, true);
+    log.debug("[Script] Pending pin attempt flagged");
   }
 
   public void breakPin() {
-    // TODO: Force pin break
-    log.debug("[Script] Breaking Pin");
+    setFeatureFlag(KEY_BREAK_PIN_GRANTED, true);
+    log.debug("[Script] Break pin flagged");
   }
 
   public void negateAttack() {
-    // TODO: Cancel incoming attack
-    log.debug("[Script] Negating Attack");
+    setFeatureFlag(KEY_ATTACK_NEGATED, true);
+    log.debug("[Script] Attack negation flagged");
   }
 
   // ==================== Modifiers ====================
 
   public void modifyOpponentRoll(final int modifier) {
-    // TODO: Add temporary modifier to opponent's next roll
-    log.debug("[Script] Modifying Opponent Roll by {}", modifier);
+    accumulateFeatureInt(KEY_OPPONENT_ROLL_MODIFIER, modifier);
+    log.debug("[Script] Opponent roll modifier: {}", modifier);
   }
 
   public void modifyRoll(final int modifier) {
-    // TODO: Add temporary modifier to player's roll
-    log.debug("[Script] Modifying Player Roll by {}", modifier);
+    accumulateFeatureInt(KEY_PLAYER_ROLL_MODIFIER, modifier);
+    log.debug("[Script] Player roll modifier: {}", modifier);
   }
 
   public void modifyBackstageDice(final int amount) {
-    // TODO: Add bonus dice for backstage checks
-    log.debug("[Script] Adding {} dice to Backstage Check", amount);
+    accumulateFeatureInt(KEY_BACKSTAGE_DICE_BONUS, amount);
+    log.debug("[Script] Backstage dice bonus: {}", amount);
   }
 
   public void modifyAttribute(final String attribute, final int amount) {
-    // TODO: Temporary or permanent attribute buff
-    log.debug("[Script] Modifying attribute {} by {}", attribute, amount);
+    // Map well-known attributes to CampaignState fields; store the rest in featureData.
+    switch (attribute.toLowerCase()) {
+      case "health", "hp" -> {
+        if (amount >= 0) {
+          gainHitPoints(amount);
+        } else {
+          CampaignState state = campaign.getState();
+          state.setHealthPenalty(state.getHealthPenalty() + Math.abs(amount));
+          stateRepository.save(state);
+        }
+      }
+      case "stamina" -> {
+        if (amount >= 0) {
+          gainStamina(amount);
+        } else {
+          spendStamina(Math.abs(amount));
+        }
+      }
+      case "momentum" -> gainMomentum(amount);
+      case "handsize", "hand_size" -> {
+        if (amount >= 0) {
+          drawCard(amount);
+        } else {
+          CampaignState state = campaign.getState();
+          state.setHandSizePenalty(state.getHandSizePenalty() + Math.abs(amount));
+          stateRepository.save(state);
+        }
+      }
+      default -> {
+        accumulateFeatureInt(KEY_ATTRIBUTE_MODIFIER_PREFIX + attribute.toLowerCase(), amount);
+        log.debug("[Script] Stored attribute modifier: {}={}", attribute, amount);
+      }
+    }
+  }
+
+  // ==================== featureData helpers ====================
+
+  private Map<String, Object> readFeatureData() {
+    CampaignState state = campaign.getState();
+    if (state.getFeatureData() == null) {
+      return new HashMap<>();
+    }
+    try {
+      return objectMapper.readValue(
+          state.getFeatureData(), new TypeReference<Map<String, Object>>() {});
+    } catch (Exception e) {
+      log.warn("Failed to parse featureData in CampaignEffectContext", e);
+      return new HashMap<>();
+    }
+  }
+
+  private void writeFeatureData(final Map<String, Object> data) {
+    CampaignState state = campaign.getState();
+    try {
+      state.setFeatureData(objectMapper.writeValueAsString(data));
+      stateRepository.save(state);
+    } catch (Exception e) {
+      log.error("Failed to write featureData in CampaignEffectContext", e);
+    }
+  }
+
+  private void setFeatureFlag(final String key, final boolean value) {
+    Map<String, Object> data = readFeatureData();
+    data.put(key, value);
+    writeFeatureData(data);
+  }
+
+  private void accumulateFeatureInt(final String key, final int delta) {
+    Map<String, Object> data = readFeatureData();
+    int current = data.containsKey(key) ? ((Number) data.get(key)).intValue() : 0;
+    data.put(key, current + delta);
+    writeFeatureData(data);
   }
 }

--- a/src/main/java/com/github/javydreamercsw/management/service/campaign/CampaignScriptService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/campaign/CampaignScriptService.java
@@ -16,7 +16,9 @@
 */
 package com.github.javydreamercsw.management.service.campaign;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javydreamercsw.management.domain.campaign.Campaign;
+import com.github.javydreamercsw.management.domain.campaign.CampaignStateRepository;
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
 import java.io.IOException;
@@ -26,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.runtime.InvokerHelper;
@@ -35,7 +38,11 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class CampaignScriptService {
+
+  private final CampaignStateRepository campaignStateRepository;
+  private final ObjectMapper objectMapper;
 
   // Compiled script classes cached by snippet text to avoid per-call classloader creation.
   private final Map<String, Class<?>> compiledSnippetCache = new ConcurrentHashMap<>();
@@ -55,7 +62,8 @@ public class CampaignScriptService {
     }
 
     Map<String, Object> variables = new HashMap<>();
-    CampaignEffectContext context = new CampaignEffectContext(campaign);
+    CampaignEffectContext context =
+        new CampaignEffectContext(campaign, campaignStateRepository, objectMapper);
     variables.put("ctx", context);
 
     // Using Groovy's 'with' to allow calling methods on the context directly

--- a/src/main/java/com/github/javydreamercsw/management/service/segment/NPCSegmentResolutionService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/segment/NPCSegmentResolutionService.java
@@ -297,21 +297,6 @@ public class NPCSegmentResolutionService {
     return modifier;
   }
 
-  /**
-   * Returns the campaign weight penalty imposed on this wrestler by an opposing campaign player
-   * (e.g. from attackNegated or opponentRollModifier). Positive return value = this wrestler is
-   * penalised.
-   */
-  private int getCampaignOpponentPenalty(@NonNull final Wrestler wrestler) {
-    // opponentHealthPenalty is on the player's state, not the opponent's.
-    // We apply it here as a penalty to any wrestler that is a known campaign opponent.
-    // Since we can't easily identify "who is the opponent" without the segment context,
-    // we rely on opponentHealthPenalty already being absorbed into the player's weight
-    // via getHealthPenalty above. Nothing additional needed here unless the wrestler has
-    // its own opponent-facing featureData.
-    return 0;
-  }
-
   /** Add all team members as participants in the segment. */
   private void addTeamParticipants(@NonNull final Segment result, @NonNull final SegmentTeam team) {
     for (Wrestler wrestler : team.getMembers()) {

--- a/src/main/java/com/github/javydreamercsw/management/service/segment/NPCSegmentResolutionService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/segment/NPCSegmentResolutionService.java
@@ -16,7 +16,11 @@
 */
 package com.github.javydreamercsw.management.service.segment;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javydreamercsw.base.domain.wrestler.WrestlerTier;
+import com.github.javydreamercsw.management.domain.campaign.CampaignState;
+import com.github.javydreamercsw.management.domain.campaign.WrestlerAlignment;
 import com.github.javydreamercsw.management.domain.show.Show;
 import com.github.javydreamercsw.management.domain.show.segment.Segment;
 import com.github.javydreamercsw.management.domain.show.segment.SegmentRepository;
@@ -26,12 +30,14 @@ import com.github.javydreamercsw.management.domain.world.Location;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
+import com.github.javydreamercsw.management.service.campaign.CampaignEffectContext;
 import com.github.javydreamercsw.management.service.injury.InjuryService;
 import com.github.javydreamercsw.management.service.ringside.RingsideActionDataService;
 import com.github.javydreamercsw.management.service.ringside.RingsideActionService;
 import com.github.javydreamercsw.management.service.wrestler.WrestlerService;
 import java.time.Clock;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -61,6 +67,7 @@ public class NPCSegmentResolutionService {
   @Autowired private WrestlerService wrestlerService;
   @Autowired private RingsideActionService ringsideActionService;
   @Autowired private RingsideActionDataService ringsideActionDataService;
+  @Autowired private ObjectMapper objectMapper;
 
   /**
    * Resolve a team-based segment using ATW RPG mechanics. This is the core method that handles all
@@ -212,22 +219,97 @@ public class NPCSegmentResolutionService {
     };
   }
 
-  /** Get health penalty based on bumps and injuries in a specific universe. */
+  /** Get health penalty based on bumps, injuries, and campaign-state penalties. */
   private int getHealthPenalty(@NonNull final Wrestler wrestler, @NonNull final Long universeId) {
     int penalty = 0;
 
-    com.github.javydreamercsw.management.domain.wrestler.WrestlerState state =
-        wrestlerService.getOrCreateState(wrestler.getId(), universeId);
-
+    WrestlerState state = wrestlerService.getOrCreateState(wrestler.getId(), universeId);
     if (state != null) {
-      // Bump penalties (each bump reduces effectiveness)
       penalty += state.getBumps();
-
-      // Injury penalties (active injuries significantly reduce effectiveness)
       penalty += injuryService.getTotalHealthPenaltyForWrestler(wrestler.getId(), universeId);
     }
 
+    // Campaign health penalty (ATW-9gf): the player's pre-match damage from scripts/backstage
+    WrestlerAlignment alignment = wrestler.getAlignment();
+    if (alignment != null
+        && alignment.getCampaign() != null
+        && alignment.getCampaign().getState() != null) {
+      penalty += alignment.getCampaign().getState().getHealthPenalty();
+      // staminaPenalty also degrades physical effectiveness (ATW-xvc)
+      penalty += alignment.getCampaign().getState().getStaminaPenalty();
+    }
+
     return penalty;
+  }
+
+  /**
+   * Returns the campaign weight modifier for a wrestler by reading pre-match script flags from
+   * featureData. Positive means the wrestler is advantaged; negative means disadvantaged. The flags
+   * are NOT consumed here — they remain until the campaign's post-match cleanup so they can also
+   * influence narration.
+   */
+  private int getCampaignWeightModifier(@NonNull final Wrestler wrestler) {
+    WrestlerAlignment alignment = wrestler.getAlignment();
+    if (alignment == null
+        || alignment.getCampaign() == null
+        || alignment.getCampaign().getState() == null) {
+      return 0;
+    }
+    CampaignState campaignState = alignment.getCampaign().getState();
+
+    // Momentum bonus translates directly to weight (ATW-8vs)
+    int modifier = campaignState.getMomentumBonus();
+
+    // Read featureData flags (ATW-32b initiative, ATW-wot negateAttack, ATW-yk1 pin,
+    // ATW-t8q rollModifier)
+    String featureData = campaignState.getFeatureData();
+    if (featureData == null) {
+      return modifier;
+    }
+    try {
+      Map<String, Object> data =
+          objectMapper.readValue(featureData, new TypeReference<Map<String, Object>>() {});
+
+      // Initiative: player acts first — +5 weight advantage (ATW-32b)
+      if (Boolean.TRUE.equals(data.get(CampaignEffectContext.KEY_INITIATIVE_GRANTED))) {
+        modifier += 5;
+      }
+      // Pending pin attempt: strong win advantage (ATW-yk1)
+      if (Boolean.TRUE.equals(data.get(CampaignEffectContext.KEY_PENDING_PIN_ATTEMPT))) {
+        modifier += 10;
+      }
+      // Player roll modifier: each point = 1 weight (ATW-t8q)
+      Object rollMod = data.get(CampaignEffectContext.KEY_PLAYER_ROLL_MODIFIER);
+      if (rollMod instanceof Number n) {
+        modifier += n.intValue();
+      }
+      // Attack negated: player's next incoming attack is nullified — defensive advantage (ATW-wot)
+      if (Boolean.TRUE.equals(data.get(CampaignEffectContext.KEY_ATTACK_NEGATED))) {
+        modifier += 3;
+      }
+      // Break pin granted: player can escape the next pin — defensive advantage (ATW-yk1)
+      if (Boolean.TRUE.equals(data.get(CampaignEffectContext.KEY_BREAK_PIN_GRANTED))) {
+        modifier += 3;
+      }
+    } catch (Exception e) {
+      log.warn("Failed to read campaign featureData for wrestler {}", wrestler.getName(), e);
+    }
+    return modifier;
+  }
+
+  /**
+   * Returns the campaign weight penalty imposed on this wrestler by an opposing campaign player
+   * (e.g. from attackNegated or opponentRollModifier). Positive return value = this wrestler is
+   * penalised.
+   */
+  private int getCampaignOpponentPenalty(@NonNull final Wrestler wrestler) {
+    // opponentHealthPenalty is on the player's state, not the opponent's.
+    // We apply it here as a penalty to any wrestler that is a known campaign opponent.
+    // Since we can't easily identify "who is the opponent" without the segment context,
+    // we rely on opponentHealthPenalty already being absorbed into the player's weight
+    // via getHealthPenalty above. Nothing additional needed here unless the wrestler has
+    // its own opponent-facing featureData.
+    return 0;
   }
 
   /** Add all team members as participants in the segment. */
@@ -370,7 +452,8 @@ public class NPCSegmentResolutionService {
                     int fanWeight = Math.toIntExact(state.getFans() / 5);
                     int tierBonus = getTierBonus(state.getTier());
                     int healthPenalty = getHealthPenalty(wrestler, universeId);
-                    int weight = Math.max(1, fanWeight + tierBonus - healthPenalty);
+                    int campaignMod = getCampaignWeightModifier(wrestler);
+                    int weight = Math.max(1, fanWeight + tierBonus - healthPenalty + campaignMod);
                     if (isHomeTerritory(wrestler)) {
                       weight += (int) (weight * 0.10);
                       log.debug(

--- a/src/test/java/com/github/javydreamercsw/management/service/campaign/CampaignScriptServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/campaign/CampaignScriptServiceTest.java
@@ -17,15 +17,30 @@
 package com.github.javydreamercsw.management.service.campaign;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javydreamercsw.management.domain.campaign.Campaign;
+import com.github.javydreamercsw.management.domain.campaign.CampaignState;
+import com.github.javydreamercsw.management.domain.campaign.CampaignStateRepository;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class CampaignScriptServiceTest {
 
-  private final CampaignScriptService scriptService = new CampaignScriptService();
+  private CampaignScriptService scriptService;
+  private CampaignStateRepository stateRepository;
+
+  @BeforeEach
+  void setUp() {
+    stateRepository = mock(CampaignStateRepository.class);
+    when(stateRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    scriptService = new CampaignScriptService(stateRepository, new ObjectMapper());
+  }
 
   @Test
   void testEvaluateSnippet() {
@@ -37,8 +52,11 @@ class CampaignScriptServiceTest {
 
   @Test
   void testExecuteEffect() {
+    CampaignState state = new CampaignState();
     Campaign campaign = new Campaign();
-    // This just verifies it runs without crashing, as methods currently only log
+    campaign.setState(state);
+    // Verifies the script runs and mutates state without crashing
     scriptService.executeEffect("spendStamina(1); gainInitiative()", campaign);
+    assertThat(state.getStaminaPenalty()).isEqualTo(1);
   }
 }


### PR DESCRIPTION


Resource methods (spendStamina, gainStamina, gainHitPoints, damage, gainMomentum, drawCard) now mutate CampaignState fields that feed into Wrestler.getEffective*() at match time. Match flow and modifier methods (gainInitiative, pin, breakPin, negateAttack, modifyRoll, modifyOpponentRoll, modifyBackstageDice, modifyAttribute) store typed flags/values in featureData under public KEY_* constants so sub-issues can wire them into the match engine and backstage action roller.

CampaignScriptService now injects CampaignStateRepository and ObjectMapper and passes them to CampaignEffectContext. Updated CampaignScriptServiceTest to use Mockito mocks and assert that executeEffect actually mutates state.