### PR TITLE
feat(ATW-xz4): replace condition HP penalty with wear-and-tear bump roll

### DIFF
--- a/src/main/java/com/github/javydreamercsw/management/domain/wrestler/Wrestler.java
+++ b/src/main/java/com/github/javydreamercsw/management/domain/wrestler/Wrestler.java
@@ -251,15 +251,9 @@ public class Wrestler extends AbstractSyncableEntity<Long> {
             .orElse(null);
 
     int bumpsValue = state != null ? state.getBumps() : 0;
-    int condition = state != null ? state.getPhysicalCondition() : 100;
     int injuryPenalty = state != null ? state.getTotalInjuryPenalty() : 0;
 
-    // Physical condition penalty: -1 health for every 5% lost from 100%
-    // Capped at -5 health points.
-    int conditionPenalty = Math.min(5, (100 - condition) / 5);
-
-    int effective =
-        startingHealth + bonus - penalty - bumpsValue - injuryPenalty - conditionPenalty;
+    int effective = startingHealth + bonus - penalty - bumpsValue - injuryPenalty;
     return Math.max(1, effective); // Never go below 1
   }
 

--- a/src/main/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationService.java
@@ -784,11 +784,20 @@ public class SegmentAdjudicationService {
     for (Wrestler wrestler : segment.getWrestlers()) {
       WrestlerState state = wrestlerService.getOrCreateState(wrestler.getId(), universeId);
       int current = state.getPhysicalCondition();
-      state.setPhysicalCondition(Math.max(0, current - baseLoss));
+      int newCondition = Math.max(0, current - baseLoss);
+      state.setPhysicalCondition(newCondition);
       wrestlerService.save(wrestler);
       log.info(
           "Applied {}% wear and tear to {} in league {}. New condition: {}%",
-          baseLoss, wrestler.getName(), universeId, state.getPhysicalCondition());
+          baseLoss, wrestler.getName(), universeId, newCondition);
+
+      int bumpChance = Math.max(0, 75 - newCondition);
+      if (bumpChance > 0 && random.nextInt(100) < bumpChance) {
+        log.info(
+            "Wear-and-tear bump triggered for {} (condition: {}%, chance: {}%)",
+            wrestler.getName(), newCondition, bumpChance);
+        wrestlerService.addBump(wrestler.getId(), universeId);
+      }
 
       // Check for retirement
       retirementService.checkRetirement(wrestler, universeId);

--- a/src/test/java/com/github/javydreamercsw/management/domain/wrestler/WrestlerHealthCalculationTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/domain/wrestler/WrestlerHealthCalculationTest.java
@@ -122,16 +122,28 @@ class WrestlerHealthCalculationTest {
   @Test
   @DisplayName("Should never allow effective health to go below 1")
   void shouldNeverAllowEffectiveHealthToGoBelowOne() {
-    // Given - Massive penalties
-    state.setBumps(2);
-    wrestler.setStartingHealth(5); // Low starting health
-    state.setPhysicalCondition(0); // Very poor condition (adds -5 penalty)
+    // Given - bumps alone drive HP below 1
+    state.setBumps(6);
+    wrestler.setStartingHealth(5);
 
     // When
     Integer effectiveHealth = wrestler.getEffectiveStartingHealth(universe.getId());
 
-    // Then - Should be 1, not negative (5 - 2 bumps - 5 condition penalty = -2, clamped to 1)
+    // Then - 5 - 6 bumps = -1, clamped to 1
     assertThat(effectiveHealth).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("Physical condition should not directly reduce effective starting health")
+  void physicalConditionShouldNotDirectlyReduceHealth() {
+    // Given - poor condition, no bumps or injuries
+    state.setPhysicalCondition(0);
+
+    // When
+    Integer effectiveHealth = wrestler.getEffectiveStartingHealth(universe.getId());
+
+    // Then - condition no longer penalises HP; bumps/injuries do
+    assertThat(effectiveHealth).isEqualTo(15);
   }
 
   @Test

--- a/src/test/java/com/github/javydreamercsw/management/service/match/WearAndTearAdjudicationTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/match/WearAndTearAdjudicationTest.java
@@ -165,4 +165,42 @@ class WearAndTearAdjudicationTest {
 
     verify(wrestlerState, never()).setPhysicalCondition(anyInt());
   }
+
+  @Test
+  void testApplyWearAndTear_ConditionBumpRollFires() {
+    // condition=50 → newCondition=48 after baseLoss=2 → bumpChance=27
+    when(wrestlerState.getPhysicalCondition()).thenReturn(50);
+    when(random.nextInt(3)).thenReturn(1); // baseLoss = 2
+    when(random.nextInt(100)).thenReturn(10); // 10 < 27, roll succeeds
+    when(segment.isMainEvent()).thenReturn(false);
+
+    segmentAdjudicationService.adjudicateMatch(segment);
+
+    verify(wrestlerService).addBump(eq(1L), anyLong());
+  }
+
+  @Test
+  void testApplyWearAndTear_ConditionBumpRollMisses() {
+    // condition=50 → newCondition=48 → bumpChance=27
+    when(wrestlerState.getPhysicalCondition()).thenReturn(50);
+    when(random.nextInt(3)).thenReturn(1); // baseLoss = 2
+    when(random.nextInt(100)).thenReturn(30); // 30 >= 27, roll misses
+    when(segment.isMainEvent()).thenReturn(false);
+
+    segmentAdjudicationService.adjudicateMatch(segment);
+
+    verify(wrestlerService, never()).addBump(anyLong(), anyLong());
+  }
+
+  @Test
+  void testApplyWearAndTear_NoRollAbove75() {
+    // condition=80 → newCondition=78 → bumpChance=0
+    when(wrestlerState.getPhysicalCondition()).thenReturn(80);
+    when(random.nextInt(3)).thenReturn(1); // baseLoss = 2
+    when(segment.isMainEvent()).thenReturn(false);
+
+    segmentAdjudicationService.adjudicateMatch(segment);
+
+    verify(wrestlerService, never()).addBump(anyLong(), anyLong());
+  }
 }


### PR DESCRIPTION
Physical condition no longer directly penalises starting HP. Instead, wrestlers at or below 75% condition risk an extra bump at the end of every match segment (chance = 75 - condition %). The existing addBump() pipeline handles the threshold check and injury creation, so the mechanic works identically for players and NPCs — it just expresses differently downstream (HP for players, match weight for NPCs).

The old conditionPenalty formula (-1 HP per 5% lost, capped at -5) is removed from getEffectiveStartingHealth; bumps and active injuries remain the only deductions.