### PR TITLE
test: add unit tests for AI narration provider services (ATW-cyv)

### DIFF
--- a/src/test/java/com/github/javydreamercsw/base/ai/claude/ClaudeSegmentNarrationServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/base/ai/claude/ClaudeSegmentNarrationServiceTest.java
@@ -1,0 +1,272 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.base.ai.claude;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.base.ai.AIServiceException;
+import com.github.javydreamercsw.base.ai.service.AiSettingsService;
+import com.github.javydreamercsw.management.service.performance.PerformanceMonitoringService;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+
+@ExtendWith(MockitoExtension.class)
+class ClaudeSegmentNarrationServiceTest {
+
+  @Mock private AiSettingsService aiSettingsService;
+  @Mock private ClaudeConfigProperties claudeConfigProperties;
+  @Mock private Environment environment;
+  @Mock private HttpClient httpClient;
+  @Mock private PerformanceMonitoringService performanceMonitoringService;
+
+  private ClaudeSegmentNarrationService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new ClaudeSegmentNarrationService(claudeConfigProperties, environment, aiSettingsService) {
+          @Override
+          protected HttpClient getHttpClient(final int timeout) {
+            return httpClient;
+          }
+        };
+    service.setPerformanceMonitoringService(performanceMonitoringService);
+  }
+
+  @Test
+  void getProviderName_returnsAnthropicClaude() {
+    assertEquals("Anthropic Claude", service.getProviderName());
+  }
+
+  @Test
+  void isAvailable_enabledWithKey_returnsTrue() {
+    when(aiSettingsService.isClaudeEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(claudeConfigProperties.getApiKey()).thenReturn("sk-test-key");
+
+    assertTrue(service.isAvailable());
+  }
+
+  @Test
+  void isAvailable_disabled_returnsFalse() {
+    when(aiSettingsService.isClaudeEnabled()).thenReturn(false);
+
+    assertFalse(service.isAvailable());
+  }
+
+  @Test
+  void isAvailable_noApiKey_returnsFalse() {
+    when(aiSettingsService.isClaudeEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(claudeConfigProperties.getApiKey()).thenReturn("");
+
+    assertFalse(service.isAvailable());
+  }
+
+  @Test
+  void isAvailable_nullApiKey_returnsFalse() {
+    when(aiSettingsService.isClaudeEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(claudeConfigProperties.getApiKey()).thenReturn(null);
+
+    assertFalse(service.isAvailable());
+  }
+
+  @Test
+  void isAvailable_testProfileActive_returnsFalse() {
+    when(aiSettingsService.isClaudeEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {"test"});
+
+    assertFalse(service.isAvailable());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_successfulResponse_returnsNarration() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {
+          "content": [{"type": "text", "text": "Epic wrestling narration!"}],
+          "usage": {"input_tokens": 100, "output_tokens": 200}
+        }
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(claudeConfigProperties.getApiUrl()).thenReturn("https://api.anthropic.com/v1/messages");
+    when(claudeConfigProperties.getModelName()).thenReturn("claude-3-haiku-20240307");
+    when(claudeConfigProperties.getApiKey()).thenReturn("sk-test-key");
+    when(claudeConfigProperties.getTimeout()).thenReturn(30);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    String result = service.generateText("Narrate a wrestling match");
+
+    assertEquals("Epic wrestling narration!", result);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_apiError_throwsAIServiceException() throws IOException, InterruptedException {
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(401);
+    when(httpResponse.body()).thenReturn("{\"error\": \"Unauthorized\"}");
+    when(claudeConfigProperties.getApiUrl()).thenReturn("https://api.anthropic.com/v1/messages");
+    when(claudeConfigProperties.getModelName()).thenReturn("claude-3-haiku-20240307");
+    when(claudeConfigProperties.getApiKey()).thenReturn("invalid-key");
+    when(claudeConfigProperties.getTimeout()).thenReturn(30);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    AIServiceException ex =
+        assertThrows(AIServiceException.class, () -> service.generateText("Narrate a match"));
+
+    // The catch(Exception e) block wraps the AIServiceException as 500
+    assertEquals(500, ex.getStatusCode());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_rateLimitError_throwsAIServiceException()
+      throws IOException, InterruptedException {
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(429);
+    when(httpResponse.body()).thenReturn("{\"error\": \"Rate limit exceeded\"}");
+    when(claudeConfigProperties.getApiUrl()).thenReturn("https://api.anthropic.com/v1/messages");
+    when(claudeConfigProperties.getModelName()).thenReturn("claude-3-haiku-20240307");
+    when(claudeConfigProperties.getApiKey()).thenReturn("sk-test-key");
+    when(claudeConfigProperties.getTimeout()).thenReturn(30);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    assertThrows(AIServiceException.class, () -> service.generateText("Narrate a match"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_timeoutException_throwsAIServiceExceptionWith504()
+      throws IOException, InterruptedException {
+    when(claudeConfigProperties.getApiUrl()).thenReturn("https://api.anthropic.com/v1/messages");
+    when(claudeConfigProperties.getModelName()).thenReturn("claude-3-haiku-20240307");
+    when(claudeConfigProperties.getApiKey()).thenReturn("sk-test-key");
+    when(claudeConfigProperties.getTimeout()).thenReturn(30);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenThrow(new HttpTimeoutException("Connection timed out"));
+
+    AIServiceException ex =
+        assertThrows(AIServiceException.class, () -> service.generateText("Narrate a match"));
+
+    assertEquals(504, ex.getStatusCode());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_successWithUsage_recordsTokenUsage() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {
+          "content": [{"type": "text", "text": "Narration text"}],
+          "usage": {"input_tokens": 150, "output_tokens": 300}
+        }
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(claudeConfigProperties.getApiUrl()).thenReturn("https://api.anthropic.com/v1/messages");
+    when(claudeConfigProperties.getModelName()).thenReturn("claude-3-haiku-20240307");
+    when(claudeConfigProperties.getApiKey()).thenReturn("sk-test-key");
+    when(claudeConfigProperties.getTimeout()).thenReturn(30);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    service.generateText("Narrate a match");
+
+    verify(performanceMonitoringService).recordTokenUsage("Anthropic Claude", 150, 300);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_emptyContent_returnsNoContentMessage()
+      throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {"content": []}
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(claudeConfigProperties.getApiUrl()).thenReturn("https://api.anthropic.com/v1/messages");
+    when(claudeConfigProperties.getModelName()).thenReturn("claude-3-haiku-20240307");
+    when(claudeConfigProperties.getApiKey()).thenReturn("sk-test-key");
+    when(claudeConfigProperties.getTimeout()).thenReturn(30);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    String result = service.generateText("Narrate a match");
+
+    assertEquals("No content in AI response", result);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_sendsCorrectHeaders() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {"content": [{"type": "text", "text": "narration"}], "usage": {}}
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(claudeConfigProperties.getApiUrl()).thenReturn("https://api.anthropic.com/v1/messages");
+    when(claudeConfigProperties.getModelName()).thenReturn("claude-3-haiku-20240307");
+    when(claudeConfigProperties.getApiKey()).thenReturn("sk-abc123");
+    when(claudeConfigProperties.getTimeout()).thenReturn(30);
+
+    org.mockito.ArgumentCaptor<HttpRequest> requestCaptor =
+        org.mockito.ArgumentCaptor.forClass(HttpRequest.class);
+    when(httpClient.send(requestCaptor.capture(), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    service.generateText("Narrate a match");
+
+    HttpRequest captured = requestCaptor.getValue();
+    assertTrue(captured.headers().firstValue("x-api-key").isPresent());
+    assertEquals("sk-abc123", captured.headers().firstValue("x-api-key").get());
+    assertTrue(captured.headers().firstValue("anthropic-version").isPresent());
+    assertEquals("application/json", captured.headers().firstValue("Content-Type").get());
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/base/ai/gemini/GeminiSegmentNarrationServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/base/ai/gemini/GeminiSegmentNarrationServiceTest.java
@@ -1,0 +1,331 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.base.ai.gemini;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.base.ai.AIServiceException;
+import com.github.javydreamercsw.base.ai.service.AiSettingsService;
+import com.github.javydreamercsw.management.service.performance.PerformanceMonitoringService;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+
+@ExtendWith(MockitoExtension.class)
+class GeminiSegmentNarrationServiceTest {
+
+  @Mock private AiSettingsService aiSettingsService;
+  @Mock private GeminiConfigProperties geminiConfigProperties;
+  @Mock private Environment environment;
+  @Mock private HttpClient httpClient;
+  @Mock private PerformanceMonitoringService performanceMonitoringService;
+
+  private GeminiSegmentNarrationService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new GeminiSegmentNarrationService(geminiConfigProperties, environment, aiSettingsService) {
+          @Override
+          protected HttpClient getHttpClient(final int timeout) {
+            return httpClient;
+          }
+        };
+    service.setPerformanceMonitoringService(performanceMonitoringService);
+  }
+
+  /** Returns an empty HttpHeaders to satisfy the trace-log call in callGemini(). */
+  private HttpHeaders emptyHeaders() {
+    return HttpHeaders.of(Map.<String, List<String>>of(), (k, v) -> true);
+  }
+
+  @Test
+  void getProviderName_returnsGoogleGemini() {
+    assertEquals("Google Gemini", service.getProviderName());
+  }
+
+  @Test
+  void isAvailable_enabledWithKey_returnsTrue() {
+    when(aiSettingsService.isGeminiEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(geminiConfigProperties.getApiKey()).thenReturn("AIzaSy-test-key");
+
+    assertTrue(service.isAvailable());
+  }
+
+  @Test
+  void isAvailable_disabled_returnsFalse() {
+    when(aiSettingsService.isGeminiEnabled()).thenReturn(false);
+
+    assertFalse(service.isAvailable());
+  }
+
+  @Test
+  void isAvailable_noApiKey_returnsFalse() {
+    when(aiSettingsService.isGeminiEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(geminiConfigProperties.getApiKey()).thenReturn("");
+
+    assertFalse(service.isAvailable());
+  }
+
+  @Test
+  void isAvailable_nullApiKey_returnsFalse() {
+    when(aiSettingsService.isGeminiEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(geminiConfigProperties.getApiKey()).thenReturn(null);
+
+    assertFalse(service.isAvailable());
+  }
+
+  @Test
+  void isAvailable_testProfileActive_returnsFalse() {
+    when(aiSettingsService.isGeminiEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {"test"});
+
+    assertFalse(service.isAvailable());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_successfulResponse_returnsNarration() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {
+          "candidates": [{
+            "content": {"parts": [{"text": "Epic wrestling narration!"}]},
+            "finishReason": "STOP"
+          }],
+          "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200}
+        }
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(httpResponse.headers()).thenReturn(emptyHeaders());
+    when(geminiConfigProperties.getModelName()).thenReturn("gemini-2.5-flash");
+    when(geminiConfigProperties.getApiUrl())
+        .thenReturn("https://generativelanguage.googleapis.com/v1beta/models/");
+    when(geminiConfigProperties.getApiKey()).thenReturn("AIzaSy-test-key");
+    when(geminiConfigProperties.getTimeout()).thenReturn(30);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    String result = service.generateText("Narrate a wrestling match");
+
+    assertEquals("Epic wrestling narration!", result);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_multipleTextParts_concatenatesAll() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {
+          "candidates": [{
+            "content": {"parts": [{"text": "Part one. "}, {"text": "Part two."}]},
+            "finishReason": "STOP"
+          }]
+        }
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(httpResponse.headers()).thenReturn(emptyHeaders());
+    when(geminiConfigProperties.getModelName()).thenReturn("gemini-2.5-flash");
+    when(geminiConfigProperties.getApiUrl())
+        .thenReturn("https://generativelanguage.googleapis.com/v1beta/models/");
+    when(geminiConfigProperties.getApiKey()).thenReturn("AIzaSy-test-key");
+    when(geminiConfigProperties.getTimeout()).thenReturn(30);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    String result = service.generateText("Narrate a match");
+
+    assertEquals("Part one. Part two.", result);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_apiError_throwsAIServiceException() throws IOException, InterruptedException {
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(403);
+    when(httpResponse.body()).thenReturn("{\"error\": \"API key invalid\"}");
+    when(httpResponse.headers()).thenReturn(emptyHeaders());
+    when(geminiConfigProperties.getModelName()).thenReturn("gemini-2.5-flash");
+    when(geminiConfigProperties.getApiUrl())
+        .thenReturn("https://generativelanguage.googleapis.com/v1beta/models/");
+    when(geminiConfigProperties.getApiKey()).thenReturn("bad-key");
+    when(geminiConfigProperties.getTimeout()).thenReturn(30);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    // The catch(Exception e) block wraps the AIServiceException as 500
+    AIServiceException ex =
+        assertThrows(AIServiceException.class, () -> service.generateText("Narrate a match"));
+
+    assertEquals(500, ex.getStatusCode());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_rateLimitError_throwsAIServiceException()
+      throws IOException, InterruptedException {
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(429);
+    when(httpResponse.body())
+        .thenReturn("{\"error\": {\"code\": 429, \"message\": \"Resource exhausted\"}}");
+    when(httpResponse.headers()).thenReturn(emptyHeaders());
+    when(geminiConfigProperties.getModelName()).thenReturn("gemini-2.5-flash");
+    when(geminiConfigProperties.getApiUrl())
+        .thenReturn("https://generativelanguage.googleapis.com/v1beta/models/");
+    when(geminiConfigProperties.getApiKey()).thenReturn("AIzaSy-test-key");
+    when(geminiConfigProperties.getTimeout()).thenReturn(30);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    assertThrows(AIServiceException.class, () -> service.generateText("Narrate a match"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_timeoutException_throwsAIServiceExceptionWith504()
+      throws IOException, InterruptedException {
+    when(geminiConfigProperties.getModelName()).thenReturn("gemini-2.5-flash");
+    when(geminiConfigProperties.getApiUrl())
+        .thenReturn("https://generativelanguage.googleapis.com/v1beta/models/");
+    when(geminiConfigProperties.getApiKey()).thenReturn("AIzaSy-test-key");
+    when(geminiConfigProperties.getTimeout()).thenReturn(30);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenThrow(new HttpTimeoutException("Connection timed out"));
+
+    AIServiceException ex =
+        assertThrows(AIServiceException.class, () -> service.generateText("Narrate a match"));
+
+    assertEquals(504, ex.getStatusCode());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_successWithUsage_recordsTokenUsage() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {
+          "candidates": [{
+            "content": {"parts": [{"text": "Narration text"}]},
+            "finishReason": "STOP"
+          }],
+          "usageMetadata": {"promptTokenCount": 150, "candidatesTokenCount": 300}
+        }
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(httpResponse.headers()).thenReturn(emptyHeaders());
+    when(geminiConfigProperties.getModelName()).thenReturn("gemini-2.5-flash");
+    when(geminiConfigProperties.getApiUrl())
+        .thenReturn("https://generativelanguage.googleapis.com/v1beta/models/");
+    when(geminiConfigProperties.getApiKey()).thenReturn("AIzaSy-test-key");
+    when(geminiConfigProperties.getTimeout()).thenReturn(30);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    service.generateText("Narrate a match");
+
+    verify(performanceMonitoringService).recordTokenUsage("Google Gemini", 150, 300);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_emptyCandidates_returnsNoContentMessage()
+      throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {"candidates": []}
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(httpResponse.headers()).thenReturn(emptyHeaders());
+    when(geminiConfigProperties.getModelName()).thenReturn("gemini-2.5-flash");
+    when(geminiConfigProperties.getApiUrl())
+        .thenReturn("https://generativelanguage.googleapis.com/v1beta/models/");
+    when(geminiConfigProperties.getApiKey()).thenReturn("AIzaSy-test-key");
+    when(geminiConfigProperties.getTimeout()).thenReturn(30);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    String result = service.generateText("Narrate a match");
+
+    assertEquals("No content in AI response", result);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_appendsApiKeyToUrl() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {
+          "candidates": [{"content": {"parts": [{"text": "ok"}]}, "finishReason": "STOP"}]
+        }
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(httpResponse.headers()).thenReturn(emptyHeaders());
+    when(geminiConfigProperties.getModelName()).thenReturn("gemini-2.5-flash");
+    when(geminiConfigProperties.getApiUrl())
+        .thenReturn("https://generativelanguage.googleapis.com/v1beta/models/");
+    when(geminiConfigProperties.getApiKey()).thenReturn("AIzaSy-abc123");
+    when(geminiConfigProperties.getTimeout()).thenReturn(30);
+
+    org.mockito.ArgumentCaptor<HttpRequest> requestCaptor =
+        org.mockito.ArgumentCaptor.forClass(HttpRequest.class);
+    when(httpClient.send(requestCaptor.capture(), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    service.generateText("Narrate a match");
+
+    String uri = requestCaptor.getValue().uri().toString();
+    assertTrue(uri.contains("key=AIzaSy-abc123"), "URL should contain the API key as query param");
+    assertTrue(uri.contains("gemini-2.5-flash"), "URL should contain the model name");
+    assertTrue(uri.contains(":generateContent"), "URL should end with :generateContent");
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/base/ai/gemini/GeminiSegmentNarrationServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/base/ai/gemini/GeminiSegmentNarrationServiceTest.java
@@ -34,7 +34,6 @@ import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/github/javydreamercsw/base/ai/gemini/GeminiSegmentNarrationServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/base/ai/gemini/GeminiSegmentNarrationServiceTest.java
@@ -68,7 +68,7 @@ class GeminiSegmentNarrationServiceTest {
 
   /** Returns an empty HttpHeaders to satisfy the trace-log call in callGemini(). */
   private HttpHeaders emptyHeaders() {
-    return HttpHeaders.of(Map.<String, List<String>>of(), (k, v) -> true);
+    return HttpHeaders.of(Map.of(), (k, v) -> true);
   }
 
   @Test

--- a/src/test/java/com/github/javydreamercsw/base/ai/openai/OpenAISegmentNarrationServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/base/ai/openai/OpenAISegmentNarrationServiceTest.java
@@ -1,0 +1,412 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.base.ai.openai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.base.ai.AIServiceException;
+import com.github.javydreamercsw.base.ai.SegmentNarrationConfig;
+import com.github.javydreamercsw.base.ai.service.AiSettingsService;
+import com.github.javydreamercsw.management.service.performance.PerformanceMonitoringService;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.core.env.Environment;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OpenAISegmentNarrationServiceTest {
+
+  @Mock private AiSettingsService aiSettingsService;
+  @Mock private OpenAIConfigProperties openAIConfigProperties;
+  @Mock private Environment environment;
+  @Mock private SegmentNarrationConfig segmentNarrationConfig;
+  @Mock private HttpClient httpClient;
+  @Mock private PerformanceMonitoringService performanceMonitoringService;
+
+  private SegmentNarrationConfig.AI aiConfig;
+  private OpenAISegmentNarrationService service;
+
+  @BeforeEach
+  void setUp() {
+    aiConfig = new SegmentNarrationConfig.AI();
+    when(segmentNarrationConfig.getAi()).thenReturn(aiConfig);
+
+    service =
+        new OpenAISegmentNarrationService(
+            openAIConfigProperties, environment, segmentNarrationConfig, aiSettingsService) {
+          @Override
+          protected HttpClient getHttpClient(final int timeout) {
+            return httpClient;
+          }
+        };
+    service.setPerformanceMonitoringService(performanceMonitoringService);
+  }
+
+  @Test
+  void getProviderName_defaultModel_returnsGpt35() {
+    // getModel() returns the default when premium setting is not the premium model
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-3.5-turbo");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4");
+
+    assertEquals("OpenAI GPT-3.5", service.getProviderName());
+  }
+
+  @Test
+  void getProviderName_premiumModel_returnsGpt4() {
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4");
+
+    assertEquals("OpenAI GPT-4", service.getProviderName());
+  }
+
+  @Test
+  void getProviderName_nullModel_returnsUnknown() {
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn(null);
+    when(openAIConfigProperties.getDefaultModel()).thenReturn(null);
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4");
+
+    assertEquals("OpenAI Unknown", service.getProviderName());
+  }
+
+  @Test
+  void isAvailable_enabledWithKey_returnsTrue() {
+    when(aiSettingsService.isOpenAIEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(aiSettingsService.getOpenAIApiKey()).thenReturn("sk-test-key");
+
+    assertTrue(service.isAvailable());
+  }
+
+  @Test
+  void isAvailable_disabled_returnsFalse() {
+    when(aiSettingsService.isOpenAIEnabled()).thenReturn(false);
+
+    assertFalse(service.isAvailable());
+  }
+
+  @Test
+  void isAvailable_noApiKey_returnsFalse() {
+    when(aiSettingsService.isOpenAIEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(aiSettingsService.getOpenAIApiKey()).thenReturn("");
+
+    assertFalse(service.isAvailable());
+  }
+
+  @Test
+  void isAvailable_nullApiKey_returnsFalse() {
+    when(aiSettingsService.isOpenAIEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(aiSettingsService.getOpenAIApiKey()).thenReturn(null);
+
+    assertFalse(service.isAvailable());
+  }
+
+  @Test
+  void isAvailable_testProfileActive_returnsFalse() {
+    when(aiSettingsService.isOpenAIEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {"test"});
+
+    assertFalse(service.isAvailable());
+  }
+
+  @Test
+  void generateText_notAvailable_throwsAIServiceException() {
+    when(aiSettingsService.isOpenAIEnabled()).thenReturn(false);
+    // callOpenAI checks isAvailable() first — which itself checks isOpenAIEnabled
+    // We need to also set up for the isAvailable call path
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4");
+
+    AIServiceException ex =
+        assertThrows(AIServiceException.class, () -> service.generateText("Narrate a match"));
+
+    assertEquals(400, ex.getStatusCode());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_successfulResponse_returnsNarration() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {
+          "choices": [{
+            "message": {"role": "assistant", "content": "Epic wrestling narration!"},
+            "finish_reason": "stop"
+          }],
+          "usage": {"prompt_tokens": 100, "completion_tokens": 200}
+        }
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(aiSettingsService.isOpenAIEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(aiSettingsService.getOpenAIApiKey()).thenReturn("sk-test-key");
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getApiUrl())
+        .thenReturn("https://api.openai.com/v1/chat/completions");
+    when(openAIConfigProperties.getMaxTokens()).thenReturn(1000);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    String result = service.generateText("Narrate a wrestling match");
+
+    assertEquals("Epic wrestling narration!", result);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_apiError_throwsAIServiceException() throws IOException, InterruptedException {
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(401);
+    when(httpResponse.body()).thenReturn("{\"error\": {\"message\": \"Invalid API key\"}}");
+    when(aiSettingsService.isOpenAIEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(aiSettingsService.getOpenAIApiKey()).thenReturn("invalid-key");
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getApiUrl())
+        .thenReturn("https://api.openai.com/v1/chat/completions");
+    when(openAIConfigProperties.getMaxTokens()).thenReturn(1000);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    // The catch(Exception e) block wraps the AIServiceException as 500
+    AIServiceException ex =
+        assertThrows(AIServiceException.class, () -> service.generateText("Narrate a match"));
+
+    assertEquals(500, ex.getStatusCode());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_rateLimitError_throwsAIServiceException()
+      throws IOException, InterruptedException {
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(429);
+    when(httpResponse.body()).thenReturn("{\"error\": {\"message\": \"Rate limit exceeded\"}}");
+    when(aiSettingsService.isOpenAIEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(aiSettingsService.getOpenAIApiKey()).thenReturn("sk-test-key");
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getApiUrl())
+        .thenReturn("https://api.openai.com/v1/chat/completions");
+    when(openAIConfigProperties.getMaxTokens()).thenReturn(1000);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    assertThrows(AIServiceException.class, () -> service.generateText("Narrate a match"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_timeoutException_throwsAIServiceExceptionWith504()
+      throws IOException, InterruptedException {
+    when(aiSettingsService.isOpenAIEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(aiSettingsService.getOpenAIApiKey()).thenReturn("sk-test-key");
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getApiUrl())
+        .thenReturn("https://api.openai.com/v1/chat/completions");
+    when(openAIConfigProperties.getMaxTokens()).thenReturn(1000);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenThrow(new HttpTimeoutException("Connection timed out"));
+
+    AIServiceException ex =
+        assertThrows(AIServiceException.class, () -> service.generateText("Narrate a match"));
+
+    assertEquals(504, ex.getStatusCode());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_successWithUsage_recordsTokenUsage() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {
+          "choices": [{
+            "message": {"role": "assistant", "content": "Narration text"},
+            "finish_reason": "stop"
+          }],
+          "usage": {"prompt_tokens": 150, "completion_tokens": 300}
+        }
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(aiSettingsService.isOpenAIEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(aiSettingsService.getOpenAIApiKey()).thenReturn("sk-test-key");
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getApiUrl())
+        .thenReturn("https://api.openai.com/v1/chat/completions");
+    when(openAIConfigProperties.getMaxTokens()).thenReturn(1000);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    service.generateText("Narrate a match");
+
+    verify(performanceMonitoringService).recordTokenUsage("OpenAI GPT-4", 150, 300);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_emptyChoices_returnsNoContentMessage()
+      throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {"choices": []}
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(aiSettingsService.isOpenAIEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(aiSettingsService.getOpenAIApiKey()).thenReturn("sk-test-key");
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getApiUrl())
+        .thenReturn("https://api.openai.com/v1/chat/completions");
+    when(openAIConfigProperties.getMaxTokens()).thenReturn(1000);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    String result = service.generateText("Narrate a match");
+
+    assertEquals("No content in AI response", result);
+  }
+
+  @Test
+  void isUsingPremiumModel_withPremiumModel_returnsTrue() {
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+
+    assertTrue(service.isUsingPremiumModel());
+  }
+
+  @Test
+  void isUsingPremiumModel_withDefaultModel_returnsFalse() {
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4-turbo");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+
+    assertFalse(service.isUsingPremiumModel());
+  }
+
+  @Test
+  void getCostPer1KTokens_premiumModel_returnsHigherCost() {
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+
+    assertEquals(10.0, service.getCostPer1KTokens(), 0.001);
+  }
+
+  @Test
+  void getCostPer1KTokens_defaultModel_returnsLowerCost() {
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4-turbo");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+
+    assertEquals(0.50, service.getCostPer1KTokens(), 0.001);
+  }
+
+  @Test
+  void getModel_withConfiguredModel_returnsConfiguredModel() {
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4-turbo-preview");
+
+    assertEquals("gpt-4-turbo-preview", service.getModel());
+  }
+
+  @Test
+  void getModel_withEmptyConfig_returnsDefaultModel() {
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("  ");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+
+    assertEquals("gpt-3.5-turbo", service.getModel());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateText_sendsAuthorizationHeader() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {
+          "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+          "usage": {}
+        }
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(aiSettingsService.isOpenAIEnabled()).thenReturn(true);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(aiSettingsService.getOpenAIApiKey()).thenReturn("sk-abc123");
+    when(aiSettingsService.getOpenAIPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getDefaultModel()).thenReturn("gpt-3.5-turbo");
+    when(openAIConfigProperties.getPremiumModel()).thenReturn("gpt-4");
+    when(openAIConfigProperties.getApiUrl())
+        .thenReturn("https://api.openai.com/v1/chat/completions");
+    when(openAIConfigProperties.getMaxTokens()).thenReturn(1000);
+
+    org.mockito.ArgumentCaptor<HttpRequest> requestCaptor =
+        org.mockito.ArgumentCaptor.forClass(HttpRequest.class);
+    when(httpClient.send(requestCaptor.capture(), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    service.generateText("Narrate a match");
+
+    HttpRequest captured = requestCaptor.getValue();
+    assertTrue(captured.headers().firstValue("Authorization").isPresent());
+    assertEquals("Bearer sk-abc123", captured.headers().firstValue("Authorization").get());
+  }
+}


### PR DESCRIPTION
## Summary

- Adds 49 unit tests across the three AI narration provider services
- Covers `ClaudeSegmentNarrationService`, `GeminiSegmentNarrationService`, and `OpenAISegmentNarrationService`
- All services previously had zero test coverage

## What's tested

Each provider is tested for:
- `getProviderName()` returns the expected string
- `isAvailable()` — all branches: enabled+key present, disabled, empty key, null key, `test` profile active
- Successful response parsing and content extraction
- Multi-part response concatenation (Gemini)
- API error responses (4xx) → `AIServiceException`
- Network timeout → `AIServiceException` with 504 hint
- Token usage forwarded to `PerformanceMonitoringService`
- Correct HTTP request construction (URL format, auth headers)

## Test plan

- [x] `mvn test` — 2045 tests, 0 failures, 0 errors
- [x] Spotless + OpenRewrite clean (pre-push hook passed)