### PR TITLE
feat(ATW-asl): add unit tests for image generation services

### DIFF
--- a/src/main/java/com/github/javydreamercsw/base/ai/image/OpenAIImageGenerationService.java
+++ b/src/main/java/com/github/javydreamercsw/base/ai/image/OpenAIImageGenerationService.java
@@ -41,6 +41,7 @@ public class OpenAIImageGenerationService implements ImageGenerationService {
 
   private final AiSettingsService aiSettings;
   private final ObjectMapper objectMapper = new ObjectMapper();
+  private HttpClient httpClient;
 
   @Override
   public String generateImage(@NonNull final ImageRequest request) {
@@ -52,10 +53,7 @@ public class OpenAIImageGenerationService implements ImageGenerationService {
     try {
       log.info("Generating image with OpenAI. Prompt: {}", request.getPrompt());
 
-      HttpClient client =
-          HttpClient.newBuilder()
-              .connectTimeout(Duration.ofSeconds(aiSettings.getAiTimeout()))
-              .build();
+      HttpClient client = getHttpClient(aiSettings.getAiTimeout());
 
       String model =
           request.getModel() != null ? request.getModel() : aiSettings.getOpenAIImageModel();
@@ -97,6 +95,14 @@ public class OpenAIImageGenerationService implements ImageGenerationService {
       throw new AIServiceException(
           500, "Internal Server Error", getProviderName(), "Error during image generation", e);
     }
+  }
+
+  protected HttpClient getHttpClient(final int timeoutSeconds) {
+    if (httpClient == null) {
+      httpClient =
+          HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(timeoutSeconds)).build();
+    }
+    return httpClient;
   }
 
   @Override

--- a/src/main/java/com/github/javydreamercsw/base/ai/image/PollinationsImageGenerationService.java
+++ b/src/main/java/com/github/javydreamercsw/base/ai/image/PollinationsImageGenerationService.java
@@ -40,6 +40,7 @@ import org.springframework.stereotype.Service;
 public class PollinationsImageGenerationService implements ImageGenerationService {
 
   private final AiSettingsService aiSettings;
+  private HttpClient httpClient;
 
   @Override
   public String generateImage(@NonNull final ImageRequest request) {
@@ -74,11 +75,7 @@ public class PollinationsImageGenerationService implements ImageGenerationServic
       // and then return it as a Data URI (Base64).
       log.debug("Using Pollinations API Key for generation.");
       try {
-        HttpClient client =
-            HttpClient.newBuilder()
-                .version(HttpClient.Version.HTTP_1_1)
-                .connectTimeout(Duration.ofSeconds(aiSettings.getAiTimeout()))
-                .build();
+        HttpClient client = getHttpClient(aiSettings.getAiTimeout());
 
         HttpRequest httpRequest =
             HttpRequest.newBuilder()
@@ -121,6 +118,17 @@ public class PollinationsImageGenerationService implements ImageGenerationServic
 
     // Fallback to direct URL if no key (though it might be restricted)
     return url;
+  }
+
+  protected HttpClient getHttpClient(final int timeoutSeconds) {
+    if (httpClient == null) {
+      httpClient =
+          HttpClient.newBuilder()
+              .version(HttpClient.Version.HTTP_1_1)
+              .connectTimeout(Duration.ofSeconds(timeoutSeconds))
+              .build();
+    }
+    return httpClient;
   }
 
   @Override

--- a/src/test/java/com/github/javydreamercsw/base/ai/image/MockImageGenerationServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/base/ai/image/MockImageGenerationServiceTest.java
@@ -1,0 +1,86 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.base.ai.image;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MockImageGenerationServiceTest {
+
+  private MockImageGenerationService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new MockImageGenerationService();
+  }
+
+  @Test
+  void generateImage_urlFormat_returnsPlaceholderUrl() {
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder().prompt("A wrestling champion").build();
+
+    String result = service.generateImage(request);
+
+    assertThat(result).contains("via.placeholder.com");
+  }
+
+  @Test
+  void generateImage_b64Format_returnsBase64Pixel() {
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder()
+            .prompt("A wrestling belt")
+            .responseFormat("b64_json")
+            .build();
+
+    String result = service.generateImage(request);
+
+    assertThat(result)
+        .isEqualTo(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==");
+  }
+
+  @Test
+  void generateImage_b64FormatCaseInsensitive_returnsBase64Pixel() {
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder()
+            .prompt("A match")
+            .responseFormat("B64_JSON")
+            .build();
+
+    String result = service.generateImage(request);
+
+    assertThat(result).startsWith("iVBORw0KGgo");
+  }
+
+  @Test
+  void generateImage_nullPrompt_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> service.generateImage(null));
+  }
+
+  @Test
+  void getProviderName_returnsMockAi() {
+    assertThat(service.getProviderName()).isEqualTo("Mock AI");
+  }
+
+  @Test
+  void isAvailable_alwaysTrue() {
+    assertThat(service.isAvailable()).isTrue();
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/base/ai/image/OpenAIImageGenerationServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/base/ai/image/OpenAIImageGenerationServiceTest.java
@@ -1,0 +1,281 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.base.ai.image;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.base.ai.AIServiceException;
+import com.github.javydreamercsw.base.ai.service.AiSettingsService;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OpenAIImageGenerationServiceTest {
+
+  @Mock private AiSettingsService aiSettings;
+  @Mock private HttpClient httpClient;
+
+  private OpenAIImageGenerationService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new OpenAIImageGenerationService(aiSettings) {
+          @Override
+          protected HttpClient getHttpClient(final int timeoutSeconds) {
+            return httpClient;
+          }
+        };
+    when(aiSettings.getAiTimeout()).thenReturn(30);
+  }
+
+  // --- isAvailable ---
+
+  @Test
+  void isAvailable_enabledWithKey_returnsTrue() {
+    when(aiSettings.isOpenAIEnabled()).thenReturn(true);
+    when(aiSettings.getOpenAIApiKey()).thenReturn("sk-test-key");
+
+    assertThat(service.isAvailable()).isTrue();
+  }
+
+  @Test
+  void isAvailable_disabled_returnsFalse() {
+    when(aiSettings.isOpenAIEnabled()).thenReturn(false);
+
+    assertThat(service.isAvailable()).isFalse();
+  }
+
+  @Test
+  void isAvailable_enabledWithEmptyKey_returnsFalse() {
+    when(aiSettings.isOpenAIEnabled()).thenReturn(true);
+    when(aiSettings.getOpenAIApiKey()).thenReturn("");
+
+    assertThat(service.isAvailable()).isFalse();
+  }
+
+  // --- getProviderName ---
+
+  @Test
+  void getProviderName_returnsOpenAI() {
+    assertThat(service.getProviderName()).isEqualTo("OpenAI");
+  }
+
+  // --- generateImage when not available ---
+
+  @Test
+  void generateImage_whenNotAvailable_throws503() {
+    when(aiSettings.isOpenAIEnabled()).thenReturn(false);
+
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder().prompt("A wrestler").build();
+
+    assertThatThrownBy(() -> service.generateImage(request))
+        .isInstanceOf(AIServiceException.class)
+        .satisfies(ex -> assertThat(((AIServiceException) ex).getStatusCode()).isEqualTo(503));
+  }
+
+  // --- generateImage HTTP success paths ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateImage_successUrlFormat_returnsImageUrl() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {"data": [{"url": "https://openai-images.example.com/result.png"}]}
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(aiSettings.isOpenAIEnabled()).thenReturn(true);
+    when(aiSettings.getOpenAIApiKey()).thenReturn("sk-test-key");
+    when(aiSettings.getOpenAIImageModel()).thenReturn("dall-e-3");
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder().prompt("A wrestling champion").build();
+
+    String result = service.generateImage(request);
+
+    assertThat(result).isEqualTo("https://openai-images.example.com/result.png");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateImage_successB64Format_returnsBase64() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {"data": [{"b64_json": "base64encodedimagedata=="}]}
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(aiSettings.isOpenAIEnabled()).thenReturn(true);
+    when(aiSettings.getOpenAIApiKey()).thenReturn("sk-test-key");
+    when(aiSettings.getOpenAIImageModel()).thenReturn("dall-e-3");
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder()
+            .prompt("A wrestling belt")
+            .responseFormat("b64_json")
+            .build();
+
+    String result = service.generateImage(request);
+
+    assertThat(result).isEqualTo("base64encodedimagedata==");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateImage_usesRequestModelOverSettingsModel() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {"data": [{"url": "https://openai-images.example.com/result.png"}]}
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(aiSettings.isOpenAIEnabled()).thenReturn(true);
+    when(aiSettings.getOpenAIApiKey()).thenReturn("sk-test-key");
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder()
+            .prompt("A champion")
+            .model("dall-e-2")
+            .build();
+
+    String result = service.generateImage(request);
+
+    assertThat(result).isEqualTo("https://openai-images.example.com/result.png");
+  }
+
+  // --- generateImage HTTP error paths ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateImage_apiReturns401_throwsAIServiceException()
+      throws IOException, InterruptedException {
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(401);
+    when(httpResponse.body()).thenReturn("{\"error\": {\"message\": \"Invalid API key\"}}");
+    when(aiSettings.isOpenAIEnabled()).thenReturn(true);
+    when(aiSettings.getOpenAIApiKey()).thenReturn("sk-bad-key");
+    when(aiSettings.getOpenAIImageModel()).thenReturn("dall-e-3");
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder().prompt("A wrestler").build();
+
+    // The AIServiceException thrown inside the try block is caught and re-wrapped as 500
+    assertThatThrownBy(() -> service.generateImage(request))
+        .isInstanceOf(AIServiceException.class)
+        .satisfies(ex -> assertThat(((AIServiceException) ex).getStatusCode()).isEqualTo(500));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateImage_networkError_throwsAIServiceException500()
+      throws IOException, InterruptedException {
+    when(aiSettings.isOpenAIEnabled()).thenReturn(true);
+    when(aiSettings.getOpenAIApiKey()).thenReturn("sk-test-key");
+    when(aiSettings.getOpenAIImageModel()).thenReturn("dall-e-3");
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenThrow(new IOException("Connection reset"));
+
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder().prompt("A wrestler").build();
+
+    assertThatThrownBy(() -> service.generateImage(request))
+        .isInstanceOf(AIServiceException.class)
+        .satisfies(ex -> assertThat(((AIServiceException) ex).getStatusCode()).isEqualTo(500));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateImage_emptyDataArray_throwsRuntimeException()
+      throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {"data": []}
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(aiSettings.isOpenAIEnabled()).thenReturn(true);
+    when(aiSettings.getOpenAIApiKey()).thenReturn("sk-test-key");
+    when(aiSettings.getOpenAIImageModel()).thenReturn("dall-e-3");
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder().prompt("A wrestler").build();
+
+    assertThatThrownBy(() -> service.generateImage(request))
+        .isInstanceOf(AIServiceException.class)
+        .satisfies(ex -> assertThat(((AIServiceException) ex).getStatusCode()).isEqualTo(500));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateImage_sendsAuthorizationHeader() throws IOException, InterruptedException {
+    String responseJson =
+        """
+        {"data": [{"url": "https://openai-images.example.com/result.png"}]}
+        """;
+
+    HttpResponse<String> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(responseJson);
+    when(aiSettings.isOpenAIEnabled()).thenReturn(true);
+    when(aiSettings.getOpenAIApiKey()).thenReturn("sk-abc123");
+    when(aiSettings.getOpenAIImageModel()).thenReturn("dall-e-3");
+
+    org.mockito.ArgumentCaptor<HttpRequest> requestCaptor =
+        org.mockito.ArgumentCaptor.forClass(HttpRequest.class);
+    when(httpClient.send(requestCaptor.capture(), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    service.generateImage(ImageGenerationService.ImageRequest.builder().prompt("A match").build());
+
+    HttpRequest captured = requestCaptor.getValue();
+    assertThat(captured.headers().firstValue("Authorization")).hasValue("Bearer sk-abc123");
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/base/ai/image/PollinationsImageGenerationServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/base/ai/image/PollinationsImageGenerationServiceTest.java
@@ -16,61 +16,161 @@
 */
 package com.github.javydreamercsw.base.ai.image;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.github.javydreamercsw.base.ai.AIServiceException;
 import com.github.javydreamercsw.base.ai.service.AiSettingsService;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PollinationsImageGenerationServiceTest {
 
   @Mock private AiSettingsService aiSettingsService;
+  @Mock private HttpClient httpClient;
 
   private PollinationsImageGenerationService service;
 
   @BeforeEach
   void setUp() {
-    service = new PollinationsImageGenerationService(aiSettingsService);
+    service =
+        new PollinationsImageGenerationService(aiSettingsService) {
+          @Override
+          protected HttpClient getHttpClient(final int timeoutSeconds) {
+            return httpClient;
+          }
+        };
+    when(aiSettingsService.getAiTimeout()).thenReturn(30);
+    when(aiSettingsService.getPollinationsApiKey()).thenReturn("");
   }
 
+  // --- no-API-key path (returns URL directly) ---
+
   @Test
-  void testGenerateImage() {
+  void generateImage_noApiKey_returnsDirectUrl() {
     ImageGenerationService.ImageRequest request =
         ImageGenerationService.ImageRequest.builder().prompt("A wrestling champion").build();
 
     String result = service.generateImage(request);
 
-    assertEquals(
-        "https://gen.pollinations.ai/image/A+wrestling+champion?nologo=true&model=flux&width=1024&height=1024",
-        result);
+    assertThat(result)
+        .isEqualTo(
+            "https://gen.pollinations.ai/image/A+wrestling+champion?nologo=true&model=flux&width=1024&height=1024");
   }
 
   @Test
-  void testGenerateImageWithCustomSize() {
+  void generateImage_customSize_includesWidthHeight() {
     ImageGenerationService.ImageRequest request =
         ImageGenerationService.ImageRequest.builder().prompt("A belt").size("512x512").build();
 
     String result = service.generateImage(request);
 
-    assertEquals(
-        "https://gen.pollinations.ai/image/A+belt?nologo=true&model=flux&width=512&height=512",
-        result);
+    assertThat(result)
+        .isEqualTo(
+            "https://gen.pollinations.ai/image/A+belt?nologo=true&model=flux&width=512&height=512");
   }
 
   @Test
-  void testIsAvailable() {
+  void generateImage_customModel_includesModelParam() {
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder().prompt("A champion").model("turbo").build();
+
+    String result = service.generateImage(request);
+
+    assertThat(result).contains("model=turbo");
+  }
+
+  // --- API-key path (makes HTTP request) ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateImage_withApiKey_success_returnsDataUri() throws IOException, InterruptedException {
+    byte[] fakeImage = new byte[] {1, 2, 3, 4};
+    HttpResponse<byte[]> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(fakeImage);
+    HttpHeaders headers = mock(HttpHeaders.class);
+    when(headers.firstValue("Content-Type")).thenReturn(Optional.of("image/png"));
+    when(httpResponse.headers()).thenReturn(headers);
+    when(aiSettingsService.getPollinationsApiKey()).thenReturn("poll-api-key");
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder().prompt("A wrestler").build();
+
+    String result = service.generateImage(request);
+
+    assertThat(result).startsWith("data:image/png;base64,");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateImage_withApiKey_httpError_throwsAIServiceException()
+      throws IOException, InterruptedException {
+    HttpResponse<byte[]> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.statusCode()).thenReturn(403);
+    when(aiSettingsService.getPollinationsApiKey()).thenReturn("poll-api-key");
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder().prompt("A wrestler").build();
+
+    // The AIServiceException thrown inside the try block is caught and re-wrapped as 500
+    assertThatThrownBy(() -> service.generateImage(request))
+        .isInstanceOf(AIServiceException.class)
+        .satisfies(ex -> assertThat(((AIServiceException) ex).getStatusCode()).isEqualTo(500));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void generateImage_withApiKey_networkError_throwsAIServiceException500()
+      throws IOException, InterruptedException {
+    when(aiSettingsService.getPollinationsApiKey()).thenReturn("poll-api-key");
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenThrow(new IOException("Connection reset"));
+
+    ImageGenerationService.ImageRequest request =
+        ImageGenerationService.ImageRequest.builder().prompt("A wrestler").build();
+
+    assertThatThrownBy(() -> service.generateImage(request))
+        .isInstanceOf(AIServiceException.class)
+        .satisfies(ex -> assertThat(((AIServiceException) ex).getStatusCode()).isEqualTo(500));
+  }
+
+  // --- isAvailable / getProviderName ---
+
+  @Test
+  void isAvailable_whenEnabled_returnsTrue() {
     when(aiSettingsService.isPollinationsEnabled()).thenReturn(true);
-    assertTrue(service.isAvailable());
+    assertThat(service.isAvailable()).isTrue();
   }
 
   @Test
-  void testGetProviderName() {
-    assertEquals("Pollinations", service.getProviderName());
+  void isAvailable_whenDisabled_returnsFalse() {
+    when(aiSettingsService.isPollinationsEnabled()).thenReturn(false);
+    assertThat(service.isAvailable()).isFalse();
+  }
+
+  @Test
+  void getProviderName_returnspollinations() {
+    assertThat(service.getProviderName()).isEqualTo("Pollinations");
   }
 }


### PR DESCRIPTION
Add protected getHttpClient() hook to OpenAIImageGenerationService and PollinationsImageGenerationService (matching AbstractSegmentNarrationService pattern) to allow HttpClient injection in tests.

New test classes:
- MockImageGenerationServiceTest (url format, b64 format, null guard, providerName, isAvailable)
- OpenAIImageGenerationServiceTest (isAvailable branches, getProviderName, 503 when unavailable, success url/b64 paths, model override, 401→500 re-wrap, network error, empty data array, Authorization header)

Extended PollinationsImageGenerationServiceTest with custom model, isAvailable=false, API-key HTTP success/error/network-error paths.