### PR TITLE
 feat(ATW-nkx): rivalry heat escalation and feud resolution pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -863,7 +863,7 @@
             <exclude>com/github/javydreamercsw/base/ai/notion/NotionHandlerTeamsIT.java</exclude>
           </excludes>
           <!-- JVM arguments for better performance and JaCoCo coverage -->
-          <argLine>@{surefireArgLine} -Xmx2g -XX:+EnableDynamicAgentLoading -Djdk.instrument.traceUsage=false -Dspring.profiles.active=test -Dflyway.cleanDisabled=false</argLine>
+          <argLine>@{surefireArgLine} -Xmx2g -XX:+EnableDynamicAgentLoading -Djdk.attach.allowAttachSelf=true -Djdk.instrument.traceUsage=false -Dspring.profiles.active=test -Dflyway.cleanDisabled=false</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/github/javydreamercsw/management/domain/show/segment/Segment.java
+++ b/src/main/java/com/github/javydreamercsw/management/domain/show/segment/Segment.java
@@ -136,6 +136,9 @@ public class Segment extends AbstractSyncableEntity<Long> {
   @Column(name = "crowd_noise_level")
   @Min(0) @jakarta.validation.constraints.Max(100) private Integer crowdNoiseLevel = 0;
 
+  @Column(name = "rivalry_id")
+  private Long rivalryId;
+
   // Segment participants
   @OneToMany(
       mappedBy = "segment",

--- a/src/main/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationService.java
@@ -342,6 +342,20 @@ public class SegmentAdjudicationService {
           }
         });
 
+    // If the AI tagged a specific rivalry, boost its heat directly before the generic pair-scan.
+    if (segment.getRivalryId() != null) {
+      int targetedHeat = segment.getShow().isPremiumLiveEvent() ? 3 : 2;
+      rivalryService.addHeat(
+          segment.getRivalryId(),
+          targetedHeat,
+          "AI-booked segment: " + segment.getSegmentType().getName());
+      log.debug(
+          "Added {} heat to rivalry {} from AI-booked segment {}",
+          targetedHeat,
+          segment.getRivalryId(),
+          segment.getId());
+    }
+
     // Add heat to rivalries
     int heat = 1;
     String segmentTypeName = segment.getSegmentType().getName();
@@ -404,28 +418,38 @@ public class SegmentAdjudicationService {
           feudResolutionService.attemptFeudResolution(feud);
         }
       }
-      // Check if feuds should be resolved.
-      switch (segment.getSegmentType().getName()) {
-        case "Tag Team":
-          attemptRivalryResolution(segment.getWrestlers().get(0), segment.getWrestlers().get(2));
-          attemptRivalryResolution(segment.getWrestlers().get(0), segment.getWrestlers().get(3));
-          attemptRivalryResolution(segment.getWrestlers().get(1), segment.getWrestlers().get(2));
-          attemptRivalryResolution(segment.getWrestlers().get(1), segment.getWrestlers().get(3));
-          break;
-        case "Abu Dhabi Rumble":
-        case "One on One":
-        case "Free-for-All":
-        default:
-          List<Wrestler> wrestlers = segment.getWrestlers();
-          if (!wrestlers.isEmpty()) {
-            Wrestler baseWrestler = winners.isEmpty() ? wrestlers.get(0) : winners.get(0);
-            for (Wrestler other : wrestlers) {
-              if (!baseWrestler.equals(other)) {
-                attemptRivalryResolution(baseWrestler, other);
+      // If the AI tagged a specific rivalry, attempt resolution on it directly.
+      if (segment.getRivalryId() != null) {
+        DiceBag diceBag = new DiceBag(20);
+        rivalryService.attemptResolution(segment.getRivalryId(), diceBag.roll(), diceBag.roll());
+        log.info(
+            "Attempted resolution of AI-tagged rivalry {} after PLE segment {}",
+            segment.getRivalryId(),
+            segment.getId());
+      } else {
+        // Fall back to generic pair-scan when no rivalry was explicitly tagged.
+        switch (segment.getSegmentType().getName()) {
+          case "Tag Team":
+            attemptRivalryResolution(segment.getWrestlers().get(0), segment.getWrestlers().get(2));
+            attemptRivalryResolution(segment.getWrestlers().get(0), segment.getWrestlers().get(3));
+            attemptRivalryResolution(segment.getWrestlers().get(1), segment.getWrestlers().get(2));
+            attemptRivalryResolution(segment.getWrestlers().get(1), segment.getWrestlers().get(3));
+            break;
+          case "Abu Dhabi Rumble":
+          case "One on One":
+          case "Free-for-All":
+          default:
+            List<Wrestler> wrestlers = segment.getWrestlers();
+            if (!wrestlers.isEmpty()) {
+              Wrestler baseWrestler = winners.isEmpty() ? wrestlers.get(0) : winners.get(0);
+              for (Wrestler other : wrestlers) {
+                if (!baseWrestler.equals(other)) {
+                  attemptRivalryResolution(baseWrestler, other);
+                }
               }
             }
-          }
-          break;
+            break;
+        }
       }
     }
 

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ProposedSegment.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ProposedSegment.java
@@ -28,6 +28,7 @@ public class ProposedSegment {
   private String summary;
   private String notes;
   private List<String> participants;
+  private Long rivalryId;
   private List<String> winners;
   private Boolean isTitleSegment = false;
   private Set<Title> titles = new java.util.HashSet<>();

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiService.java
@@ -93,6 +93,7 @@ public class ShowPlanningAiService {
                     segment.setSummary(dto.getOutcome());
                     segment.setNotes(dto.getNotes());
                     segment.setParticipants(dto.getParticipants());
+                    segment.setRivalryId(dto.getRivalryId());
                     return segment;
                   })
               .collect(java.util.stream.Collectors.toList());
@@ -120,6 +121,13 @@ public class ShowPlanningAiService {
          coherent show by generating a list of segments in JSON format.
 
         """);
+    if (context.isPremiumLiveEvent()) {
+      prompt.append(
+          """
+          **THIS IS A PREMIUM LIVE EVENT (PLE).** Apply PLE-specific booking rules (see below).
+
+          """);
+    }
     prompt.append("Here is the context for the show:\n");
 
     if (context.getShowTemplate() != null) {
@@ -203,7 +211,9 @@ public class ShowPlanningAiService {
           .forEach(
               rivalry ->
                   prompt
-                      .append("- Name: ")
+                      .append("- Id: ")
+                      .append(rivalry.getId())
+                      .append(", Name: ")
                       .append(rivalry.getName())
                       .append(", Participants: ")
                       .append(String.join(", ", rivalry.getParticipants()))
@@ -350,6 +360,19 @@ public class ShowPlanningAiService {
         - Within the same calendar week, avoid having a wrestler in more than one match. The\
          exception is for Premium Live Event (PLE) where this is not avoidable.
         """);
+    if (context.isPremiumLiveEvent()) {
+      prompt.append(
+          """
+
+          **PLE-Specific Booking Rules:**
+          - ALL rivalries at Heat ≥ 10 MUST have a match on this card — no deferral to a future show.
+          - ALL rivalries at Heat ≥ 30 MUST use a stipulation match from the Available Stipulation\
+           Matches list above.
+          - Every active championship MUST be defended on this card.
+          - Matches should have clear, decisive finishes — PLE is not the place for count-out or\
+           disqualification endings.
+          """);
+    }
 
     List<SegmentType> segmentTypes = segmentTypeService.findAll();
     List<String> segmentTypeDescriptions =
@@ -386,7 +409,10 @@ public class ShowPlanningAiService {
     prompt.append("  \"outcome\": \"string\",\n");
     prompt.append(
         "  \"notes\": \"string\", // Optional instructions/feedback for future AI narration\n");
-    prompt.append("  \"participants\": [\"string\"]\n");
+    prompt.append("  \"participants\": [\"string\"],\n");
+    prompt.append(
+        "  \"rivalryId\": number // Optional: the Id of the rivalry this match resolves; omit or"
+            + " null if not rivalry-driven\n");
     prompt.append("}\n");
     prompt.append("```\n\n");
     prompt

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiService.java
@@ -214,9 +214,18 @@ public class ShowPlanningAiService {
                     .append(classification)
                     .append("\n");
               });
-      prompt.append("\n**Rivalry Resolution Rules:**\n");
-      prompt.append("- At 10 Heat: They must wrestle at the next PLE show\n");
-      prompt.append("- At 30 Heat → forced into High Heat Rule Match\n");
+      prompt.append("\n**Rivalry Classification Rules:**\n");
+      prompt.append(
+          """
+          - MUST_BOOK (Heat 10-19): This rivalry MUST have a segment on this show. Book a match \
+          or a promo confrontation — do not skip it.
+          - PLE_RESOLUTION_ELIGIBLE (Heat 20-29): This rivalry is hot enough to headline a PLE. \
+          On a regular show, build tension with a confrontation, brawl, or non-finish match. \
+          On a PLE, give it a decisive match.
+          - STIPULATION_REQUIRED (Heat ≥ 30): This rivalry has reached maximum intensity. It MUST \
+          have a match with a stipulation from the Available Stipulation Matches list below. \
+          Use a decisive, no-DQ finish — do not end with a count-out or disqualification.
+          """);
       List<SegmentRule> highHeatRules = segmentRuleService.getHighHeatRules();
       List<String> highHeatRuleDescriptions =
           highHeatRules.stream()

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiService.java
@@ -185,43 +185,35 @@ public class ShowPlanningAiService {
                       .append("\n"));
     }
 
-    if (context.getRecentPromos() != null && !context.getRecentPromos().isEmpty()) {
-      prompt.append("Recent Promos (up to 10):\n");
-      context.getRecentPromos().stream()
-          .limit(10)
-          .forEach(
-              promo ->
-                  prompt
-                      .append("- Name: ")
-                      .append(promo.getName())
-                      .append(", Summary: ")
-                      .append(promo.getSummary())
-                      .append(", Participants: ")
-                      .append(String.join(", ", promo.getParticipants()))
-                      .append(", Show: ")
-                      .append(promo.getShowName())
-                      .append(", Date: ")
-                      .append(promo.getShowDate())
-                      .append("\n"));
-    }
     if (context.getCurrentRivalries() != null && !context.getCurrentRivalries().isEmpty()) {
-      prompt.append("Current Rivalries:\n");
+      prompt.append("Current Rivalries (heat ≥ 10 only):\n");
       context
           .getCurrentRivalries()
           .forEach(
-              rivalry ->
-                  prompt
-                      .append("- Id: ")
-                      .append(rivalry.getId())
-                      .append(", Name: ")
-                      .append(rivalry.getName())
-                      .append(", Participants: ")
-                      .append(String.join(", ", rivalry.getParticipants()))
-                      .append(", Heat: ")
-                      .append(rivalry.getHeat())
-                      .append(", Priority: ")
-                      .append(rivalry.getPriority())
-                      .append("\n"));
+              rivalry -> {
+                String classification;
+                if (rivalry.getHeat() >= 30) {
+                  classification = "STIPULATION_REQUIRED";
+                } else if (rivalry.getHeat() >= 20) {
+                  classification = "PLE_RESOLUTION_ELIGIBLE";
+                } else {
+                  classification = "MUST_BOOK";
+                }
+                prompt
+                    .append("- Id: ")
+                    .append(rivalry.getId())
+                    .append(", Name: ")
+                    .append(rivalry.getName())
+                    .append(", Participants: ")
+                    .append(String.join(", ", rivalry.getParticipants()))
+                    .append(", Heat: ")
+                    .append(rivalry.getHeat())
+                    .append(", Priority: ")
+                    .append(rivalry.getPriority())
+                    .append(", Classification: ")
+                    .append(classification)
+                    .append("\n");
+              });
       prompt.append("\n**Rivalry Resolution Rules:**\n");
       prompt.append("- At 10 Heat: They must wrestle at the next PLE show\n");
       prompt.append("- At 30 Heat → forced into High Heat Rule Match\n");
@@ -234,20 +226,6 @@ public class ShowPlanningAiService {
           .append("Available Stipulation Matches: ")
           .append(String.join(", ", highHeatRuleDescriptions))
           .append("\n\n");
-    }
-
-    if (context.getWrestlerHeats() != null && !context.getWrestlerHeats().isEmpty()) {
-      prompt.append("Wrestler Heat:\n");
-      context
-          .getWrestlerHeats()
-          .forEach(
-              heat ->
-                  prompt
-                      .append("- Wrestler: ")
-                      .append(heat.getWrestlerName())
-                      .append(", Heat: ")
-                      .append(heat.getHeat())
-                      .append("\n"));
     }
 
     if (context.getChampionships() != null && !context.getChampionships().isEmpty()) {

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiService.java
@@ -387,7 +387,7 @@ public class ShowPlanningAiService {
     if (!segmentTypes.isEmpty()) {
       prompt
           .append("  \"type\": \"string\", // e.g., \"")
-          .append(segmentTypes.get(0).getName())
+          .append(segmentTypes.getFirst().getName())
           .append("\"\n");
     } else {
       prompt.append("  \"type\": \"string\", // e.g., \"Match\"\n");

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningContext.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningContext.java
@@ -36,4 +36,5 @@ public class ShowPlanningContext {
   private List<ShowPlanningWrestlerHeat> wrestlerHeats;
   private List<Faction> factions;
   private Instant showDate;
+  private boolean isPremiumLiveEvent;
 }

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningContext.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningContext.java
@@ -28,12 +28,10 @@ import lombok.Data;
 public class ShowPlanningContext {
   private List<Segment> recentSegments;
   private List<Rivalry> currentRivalries;
-  private List<Segment> recentPromos;
   private ShowTemplate showTemplate;
   private List<ShowPlanningChampionship> championships;
   private ShowPlanningPle nextPle;
   private List<Wrestler> fullRoster;
-  private List<ShowPlanningWrestlerHeat> wrestlerHeats;
   private List<Faction> factions;
   private Instant showDate;
   private boolean isPremiumLiveEvent;

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningService.java
@@ -267,6 +267,7 @@ public class ShowPlanningService {
       segment.setNarration(proposedSegment.getNarration());
       segment.setSummary(proposedSegment.getSummary());
       segment.setNotes(proposedSegment.getNotes());
+      segment.setRivalryId(proposedSegment.getRivalryId());
       segment.setSegmentOrder(currentSegmentCount + i + 1);
       segment.setIsTitleSegment(proposedSegment.getIsTitleSegment());
       if (proposedSegment.getTitles() != null && !proposedSegment.getTitles().isEmpty()) {

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningService.java
@@ -96,6 +96,7 @@ public class ShowPlanningService {
     // Get segments from the last 7 days
     Instant showDate = show.getShowDate().atStartOfDay(clock.getZone()).toInstant();
     context.setShowDate(showDate);
+    context.setPremiumLiveEvent(show.isPremiumLiveEvent());
     Instant lastWeek = showDate.minus(7, ChronoUnit.DAYS);
     log.debug("Getting segments between {} and {}", lastWeek, showDate);
     List<Segment> lastWeekSegments = segmentRepository.findBySegmentDateBetween(lastWeek, showDate);

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningService.java
@@ -30,7 +30,6 @@ import com.github.javydreamercsw.management.event.SegmentsApprovedEvent;
 import com.github.javydreamercsw.management.service.faction.FactionService;
 import com.github.javydreamercsw.management.service.rivalry.RivalryService;
 import com.github.javydreamercsw.management.service.segment.type.SegmentTypeService;
-import com.github.javydreamercsw.management.service.show.PromoBookingService;
 import com.github.javydreamercsw.management.service.show.ShowService;
 import com.github.javydreamercsw.management.service.show.planning.dto.ShowPlanningContextDTO;
 import com.github.javydreamercsw.management.service.show.planning.dto.ShowPlanningDtoMapper;
@@ -58,7 +57,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class ShowPlanningService {
   private final SegmentRepository segmentRepository;
   private final RivalryService rivalryService;
-  private final PromoBookingService promoBookingService;
   private final ShowPlanningDtoMapper mapper;
   private final Clock clock;
   private final TitleService titleService;
@@ -124,18 +122,10 @@ public class ShowPlanningService {
 
     context.setRecentSegments(lastWeekSegments);
 
-    // Get current rivalries
+    // Get current rivalries (full list; heat filtering happens in ShowPlanningDtoMapper)
     List<Rivalry> currentRivalries = rivalryService.getActiveRivalries();
     log.debug("Found {} active rivalries", currentRivalries.size());
     context.setCurrentRivalries(currentRivalries);
-
-    // Get promos from the last month
-    List<Segment> lastWeekPromos =
-        lastWeekSegments.stream()
-            .filter(promoBookingService::isPromoSegment)
-            .collect(Collectors.toList());
-    log.debug("Found {} promos in the last month", lastWeekPromos.size());
-    context.setRecentPromos(lastWeekPromos);
 
     // Get show template
     ShowTemplate template = new ShowTemplate();
@@ -220,11 +210,6 @@ public class ShowPlanningService {
 
     log.debug("Found {} wrestlers in the roster", allWrestlers.size());
     context.setFullRoster(allWrestlers);
-
-    // Build wrestler heat map based on rivalries, also applying gender constraint to opponents
-    List<ShowPlanningWrestlerHeat> wrestlerHeats =
-        buildWrestlerHeats(allWrestlers, genderConstraint);
-    context.setWrestlerHeats(wrestlerHeats);
 
     // Get all factions, filtered by gender constraint
     List<Faction> allFactions =
@@ -331,36 +316,5 @@ public class ShowPlanningService {
     segmentRepository.saveAll(segmentsToSave);
     log.debug("Approved and saved {} segments for show: {}", segmentsToSave.size(), show.getName());
     eventPublisher.publishEvent(new SegmentsApprovedEvent(this, show));
-  }
-
-  /**
-   * Builds wrestler heat information based on their active rivalries. For each wrestler, this
-   * creates entries for each opponent they're feuding with and the heat level of that feud.
-   */
-  private List<ShowPlanningWrestlerHeat> buildWrestlerHeats(
-      @NonNull final List<Wrestler> wrestlers, final Gender genderConstraint) {
-    List<ShowPlanningWrestlerHeat> wrestlerHeats = new ArrayList<>();
-
-    for (Wrestler wrestler : wrestlers) {
-      List<Rivalry> rivalries = rivalryService.getRivalriesForWrestler(wrestler.getId());
-      for (Rivalry rivalry : rivalries) {
-        Wrestler opponent = rivalry.getOpponent(wrestler);
-
-        // Skip opponents that don't match the gender constraint (avoiding cross-gender heat context
-        // for gender-locked shows)
-        if (genderConstraint != null && opponent.getGender() != genderConstraint) {
-          continue;
-        }
-
-        ShowPlanningWrestlerHeat heat = new ShowPlanningWrestlerHeat();
-        heat.setWrestlerName(wrestler.getName());
-        heat.setOpponentName(opponent.getName());
-        heat.setHeat(rivalry.getHeat());
-        wrestlerHeats.add(heat);
-      }
-    }
-
-    log.debug("Built {} wrestler heat entries from rivalries", wrestlerHeats.size());
-    return wrestlerHeats;
   }
 }

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningService.java
@@ -235,6 +235,67 @@ public class ShowPlanningService {
     return mapper.toDto(context);
   }
 
+  /**
+   * Validates that the proposed card covers all rivalries that are legally required.
+   *
+   * <p>Returns a list of human-readable error strings; empty means the card is valid.
+   *
+   * <ul>
+   *   <li>MUST_BOOK (heat 10-19): rivalry must appear in at least one segment.
+   *   <li>STIPULATION_REQUIRED (heat ≥ 30): rivalry must appear in a segment that carries at least
+   *       one match rule (stipulation).
+   * </ul>
+   */
+  public List<String> validateCard(
+      @NonNull final List<ProposedSegment> proposedSegments,
+      @NonNull final List<Rivalry> activeRivalries) {
+    List<String> errors = new ArrayList<>();
+
+    List<Rivalry> requiredRivalries =
+        activeRivalries.stream().filter(r -> r.getHeat() >= 10).collect(Collectors.toList());
+
+    for (Rivalry rivalry : requiredRivalries) {
+      String w1 = rivalry.getWrestler1().getName();
+      String w2 = rivalry.getWrestler2().getName();
+
+      Optional<ProposedSegment> matchingSegment =
+          proposedSegments.stream()
+              .filter(
+                  s ->
+                      (rivalry.getId() != null && rivalry.getId().equals(s.getRivalryId()))
+                          || (s.getParticipants() != null
+                              && s.getParticipants().contains(w1)
+                              && s.getParticipants().contains(w2)))
+              .findFirst();
+
+      if (matchingSegment.isEmpty()) {
+        errors.add(
+            "MUST_BOOK rivalry not on card: "
+                + w1
+                + " vs "
+                + w2
+                + " (heat="
+                + rivalry.getHeat()
+                + ")");
+      } else if (rivalry.getHeat() >= 30) {
+        ProposedSegment seg = matchingSegment.get();
+        boolean hasStipulation = seg.getRules() != null && !seg.getRules().isEmpty();
+        if (!hasStipulation) {
+          errors.add(
+              "STIPULATION_REQUIRED rivalry booked without a stipulation: "
+                  + w1
+                  + " vs "
+                  + w2
+                  + " (heat="
+                  + rivalry.getHeat()
+                  + ")");
+        }
+      }
+    }
+
+    return errors;
+  }
+
   @Transactional
   @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_BOOKER')")
   public void approveSegments(
@@ -247,6 +308,15 @@ public class ShowPlanningService {
               + show.getId()
               + ") "
               + "because showDate is not set.");
+    }
+
+    List<String> cardErrors = validateCard(proposedSegments, rivalryService.getActiveRivalries());
+    if (!cardErrors.isEmpty()) {
+      throw new IllegalStateException(
+          "Show card validation failed for '"
+              + show.getName()
+              + "':\n"
+              + String.join("\n", cardErrors));
     }
 
     List<Segment> segmentsToSave = new ArrayList<>();

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/dto/AiGeneratedSegmentDTO.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/dto/AiGeneratedSegmentDTO.java
@@ -30,4 +30,5 @@ public class AiGeneratedSegmentDTO {
   private String outcome;
   private String notes;
   private java.util.List<String> participants;
+  private Long rivalryId;
 }

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/dto/ShowPlanningContextDTO.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/dto/ShowPlanningContextDTO.java
@@ -35,4 +35,5 @@ public class ShowPlanningContextDTO {
   private List<WrestlerDTO> fullRoster;
   private List<FactionDTO> factions;
   private Instant showDate;
+  private boolean isPremiumLiveEvent;
 }

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/dto/ShowPlanningDtoMapper.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/dto/ShowPlanningDtoMapper.java
@@ -24,7 +24,6 @@ import com.github.javydreamercsw.management.domain.show.segment.SegmentParticipa
 import com.github.javydreamercsw.management.domain.show.segment.rule.SegmentRule;
 import com.github.javydreamercsw.management.domain.show.segment.type.PromoType;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
-import com.github.javydreamercsw.management.domain.wrestler.WrestlerDTO;
 import com.github.javydreamercsw.management.dto.FactionDTO;
 import com.github.javydreamercsw.management.service.show.ShowService;
 import com.github.javydreamercsw.management.service.show.planning.ShowPlanningChampionship;
@@ -48,9 +47,10 @@ public class ShowPlanningDtoMapper {
     dto.setRecentSegments(
         context.getRecentSegments().stream().map(this::toDto).collect(Collectors.toList()));
     dto.setCurrentRivalries(
-        context.getCurrentRivalries().stream().map(this::toDto).collect(Collectors.toList()));
-    dto.setRecentPromos(
-        context.getRecentPromos().stream().map(this::toDto).collect(Collectors.toList()));
+        context.getCurrentRivalries().stream()
+            .filter(r -> r.getHeat() >= 10)
+            .map(this::toDto)
+            .collect(Collectors.toList()));
     dto.setShowTemplate(context.getShowTemplate());
     if (context.getChampionships() != null) {
       dto.setChampionships(
@@ -62,13 +62,8 @@ public class ShowPlanningDtoMapper {
     if (context.getFullRoster() != null) {
       dto.setFullRoster(
           context.getFullRoster().stream()
-              .map(WrestlerDTO::new)
-              .peek(wrestlerDto -> wrestlerDto.setMoveSet(null))
+              .map(this::toRosterEntryDto)
               .collect(Collectors.toList()));
-    }
-    if (context.getWrestlerHeats() != null) {
-      dto.setWrestlerHeats(
-          context.getWrestlerHeats().stream().map(this::toDto).collect(Collectors.toList()));
     }
     if (context.getFactions() != null) {
       dto.setFactions(context.getFactions().stream().map(this::toDto).collect(Collectors.toList()));
@@ -195,13 +190,20 @@ public class ShowPlanningDtoMapper {
     return dto;
   }
 
-  public ShowPlanningWrestlerHeatDTO toDto(
-      @NonNull final com.github.javydreamercsw.management.service.show.planning.ShowPlanningWrestlerHeat
-              heat) {
-    ShowPlanningWrestlerHeatDTO dto = new ShowPlanningWrestlerHeatDTO();
-    dto.setWrestlerName(heat.getWrestlerName());
-    dto.setOpponentName(heat.getOpponentName());
-    dto.setHeat(heat.getHeat());
+  public ShowPlanningRosterEntryDTO toRosterEntryDto(@NonNull final Wrestler wrestler) {
+    ShowPlanningRosterEntryDTO dto = new ShowPlanningRosterEntryDTO();
+    dto.setName(wrestler.getName());
+    dto.setGender(wrestler.getGender() != null ? wrestler.getGender().name() : "MALE");
+    wrestler
+        .getDefaultState()
+        .ifPresent(
+            state -> {
+              dto.setTier(state.getTier());
+              dto.setFans(state.getFans());
+            });
+    if (wrestler.getAlignment() != null && wrestler.getAlignment().getAlignmentType() != null) {
+      dto.setAlignment(wrestler.getAlignment().getAlignmentType().name());
+    }
     return dto;
   }
 }

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/dto/ShowPlanningDtoMapper.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/dto/ShowPlanningDtoMapper.java
@@ -74,6 +74,7 @@ public class ShowPlanningDtoMapper {
       dto.setFactions(context.getFactions().stream().map(this::toDto).collect(Collectors.toList()));
     }
     dto.setShowDate(context.getShowDate());
+    dto.setPremiumLiveEvent(context.isPremiumLiveEvent());
     return dto;
   }
 

--- a/src/main/java/com/github/javydreamercsw/management/service/show/planning/dto/ShowPlanningRosterEntryDTO.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/planning/dto/ShowPlanningRosterEntryDTO.java
@@ -16,21 +16,16 @@
 */
 package com.github.javydreamercsw.management.service.show.planning.dto;
 
-import com.github.javydreamercsw.management.dto.FactionDTO;
-import com.github.javydreamercsw.management.service.show.planning.ShowTemplate;
-import java.time.Instant;
-import java.util.List;
+import com.github.javydreamercsw.base.domain.wrestler.WrestlerTier;
 import lombok.Data;
 
+/** Booking-relevant wrestler summary for AI show planning. Omits bios, stats, and move sets. */
 @Data
-public class ShowPlanningContextDTO {
-  private List<ShowPlanningSegmentDTO> recentSegments;
-  private List<ShowPlanningRivalryDTO> currentRivalries;
-  private ShowTemplate showTemplate;
-  private List<ShowPlanningChampionshipDTO> championships;
-  private ShowPlanningPleDTO nextPle;
-  private List<ShowPlanningRosterEntryDTO> fullRoster;
-  private List<FactionDTO> factions;
-  private Instant showDate;
-  private boolean isPremiumLiveEvent;
+public class ShowPlanningRosterEntryDTO {
+  private String name;
+  private String gender;
+  private WrestlerTier tier;
+  private Long fans;
+  private String alignment;
+  private boolean injured;
 }

--- a/src/main/resources/db/migration/h2/V80__Add_RivalryId_To_Segment.sql
+++ b/src/main/resources/db/migration/h2/V80__Add_RivalryId_To_Segment.sql
@@ -1,0 +1,1 @@
+ALTER TABLE segment ADD COLUMN rivalry_id BIGINT DEFAULT NULL;

--- a/src/main/resources/db/migration/mysql/V48__Add_RivalryId_To_Segment.sql
+++ b/src/main/resources/db/migration/mysql/V48__Add_RivalryId_To_Segment.sql
@@ -1,0 +1,1 @@
+ALTER TABLE segment ADD COLUMN rivalry_id BIGINT DEFAULT NULL;

--- a/src/test/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationServiceTest.java
@@ -155,6 +155,8 @@ class SegmentAdjudicationServiceTest {
     when(segment.getShow()).thenReturn(show);
     when(show.isPremiumLiveEvent()).thenReturn(false);
     when(matchFulfillmentRepository.findBySegment(segment)).thenReturn(Optional.empty());
+    // Default: no AI-tagged rivalry; tests that need it override this.
+    lenient().when(segment.getRivalryId()).thenReturn(null);
   }
 
   @Test
@@ -356,5 +358,62 @@ class SegmentAdjudicationServiceTest {
     // Should call awardFans for participants
     verify(wrestlerService).awardFans(eq(1L), anyLong(), anyLong());
     verify(wrestlerService).awardFans(eq(2L), anyLong(), anyLong());
+  }
+
+  @Test
+  void adjudicateMatch_aiTaggedRivalry_addsTargetedHeatOnRegularShow() {
+    when(segment.getRivalryId()).thenReturn(42L);
+    when(show.isPremiumLiveEvent()).thenReturn(false);
+    when(feudService.getActiveFeudsForWrestler(anyLong())).thenReturn(List.of());
+
+    segmentAdjudicationService.adjudicateMatch(segment);
+
+    verify(rivalryService).addHeat(eq(42L), eq(2), anyString());
+  }
+
+  @Test
+  void adjudicateMatch_aiTaggedRivalry_addsHigherHeatOnPle() {
+    when(segment.getRivalryId()).thenReturn(42L);
+    when(show.isPremiumLiveEvent()).thenReturn(true);
+    when(feudService.getActiveFeudsForWrestler(anyLong())).thenReturn(List.of());
+
+    segmentAdjudicationService.adjudicateMatch(segment);
+
+    verify(rivalryService).addHeat(eq(42L), eq(3), anyString());
+  }
+
+  @Test
+  void adjudicateMatch_aiTaggedRivalry_attemptsResolutionOnPle() {
+    com.github.javydreamercsw.management.domain.rivalry.Rivalry rivalry =
+        mock(com.github.javydreamercsw.management.domain.rivalry.Rivalry.class);
+    when(segment.getRivalryId()).thenReturn(42L);
+    when(show.isPremiumLiveEvent()).thenReturn(true);
+    when(feudService.getActiveFeudsForWrestler(anyLong())).thenReturn(List.of());
+    when(rivalryService.attemptResolution(anyLong(), anyInt(), anyInt()))
+        .thenReturn(
+            new com.github.javydreamercsw.management.service.resolution.ResolutionResult<>(
+                false, "not resolved", rivalry, 5, 6, 11));
+
+    segmentAdjudicationService.adjudicateMatch(segment);
+
+    verify(rivalryService).attemptResolution(eq(42L), anyInt(), anyInt());
+    // Generic pair-scan should NOT run when rivalryId is set
+    verify(rivalryService, never()).getRivalryBetweenWrestlers(anyLong(), anyLong());
+  }
+
+  @Test
+  void adjudicateMatch_noRivalryId_usesGenericPairScanOnPle() {
+    when(segment.getRivalryId()).thenReturn(null);
+    when(show.isPremiumLiveEvent()).thenReturn(true);
+    when(feudService.getActiveFeudsForWrestler(anyLong())).thenReturn(List.of());
+    when(rivalryService.getRivalryBetweenWrestlers(anyLong(), anyLong()))
+        .thenReturn(Optional.empty());
+
+    segmentAdjudicationService.adjudicateMatch(segment);
+
+    // Generic pair-scan must run for winner vs loser
+    verify(rivalryService).getRivalryBetweenWrestlers(eq(1L), eq(2L));
+    // Direct resolution must NOT be called with a specific id
+    verify(rivalryService, never()).attemptResolution(anyLong(), anyInt(), anyInt());
   }
 }

--- a/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiServiceTest.java
@@ -174,6 +174,10 @@ class ShowPlanningAiServiceTest {
     assertTrue(
         capturedPrompt.contains(
             "Available Stipulation Matches: Steel Cage (A match fought within a steel cage.)"));
+    assertTrue(capturedPrompt.contains("Rivalry Classification Rules:"));
+    assertTrue(capturedPrompt.contains("MUST_BOOK"));
+    assertTrue(capturedPrompt.contains("PLE_RESOLUTION_ELIGIBLE"));
+    assertTrue(capturedPrompt.contains("STIPULATION_REQUIRED"));
   }
 
   @Test

--- a/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiServiceTest.java
@@ -249,4 +249,153 @@ class ShowPlanningAiServiceTest {
       logger.setLevel(originalLevel);
     }
   }
+
+  @Test
+  void planShow_rivalryIdMappedFromAiResponse() {
+    // Given
+    ShowPlanningContextDTO context = new ShowPlanningContextDTO();
+    ShowTemplate showTemplate = new ShowTemplate();
+    showTemplate.setExpectedMatches(1);
+    showTemplate.setExpectedPromos(0);
+    context.setShowTemplate(showTemplate);
+    context.setShowDate(
+        LocalDate.of(2025, 6, 1).atStartOfDay(java.time.ZoneId.of("UTC")).toInstant());
+
+    ShowPlanningRivalryDTO rivalry = new ShowPlanningRivalryDTO();
+    rivalry.setId(42L);
+    rivalry.setName("Blood Feud");
+    rivalry.setHeat(25);
+    rivalry.setParticipants(List.of("Wrestler A", "Wrestler B"));
+    context.setCurrentRivalries(List.of(rivalry));
+
+    String aiResponseJson =
+        """
+        [
+          {
+            "segmentId": "seg1",
+            "type": "One on One",
+            "description": "Blowoff match",
+            "outcome": "Wrestler A wins",
+            "participants": ["Wrestler A", "Wrestler B"],
+            "rivalryId": 42
+          }
+        ]
+        """;
+    when(segmentNarrationService.generateText(anyString())).thenReturn(aiResponseJson);
+
+    // When
+    ProposedShow proposedShow = showPlanningAiService.planShow(context);
+
+    // Then
+    assertEquals(1, proposedShow.getSegments().size());
+    assertEquals(42L, proposedShow.getSegments().get(0).getRivalryId());
+  }
+
+  @Test
+  void planShow_promptContainsRivalryIdSchema() {
+    // Given
+    ShowPlanningContextDTO context = new ShowPlanningContextDTO();
+    ShowTemplate showTemplate = new ShowTemplate();
+    showTemplate.setExpectedMatches(1);
+    showTemplate.setExpectedPromos(0);
+    context.setShowTemplate(showTemplate);
+    context.setShowDate(
+        LocalDate.of(2025, 6, 1).atStartOfDay(java.time.ZoneId.of("UTC")).toInstant());
+
+    when(segmentNarrationService.generateText(anyString())).thenReturn("[]");
+
+    ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+
+    // When
+    showPlanningAiService.planShow(context);
+
+    // Then
+    verify(narrationServiceFactory, times(1)).generateText(promptCaptor.capture());
+    assertTrue(promptCaptor.getValue().contains("\"rivalryId\""));
+  }
+
+  @Test
+  void planShow_promptIncludesRivalryIdInRivalryListing() {
+    // Given
+    ShowPlanningContextDTO context = new ShowPlanningContextDTO();
+    ShowTemplate showTemplate = new ShowTemplate();
+    showTemplate.setExpectedMatches(1);
+    showTemplate.setExpectedPromos(0);
+    context.setShowTemplate(showTemplate);
+    context.setShowDate(
+        LocalDate.of(2025, 6, 1).atStartOfDay(java.time.ZoneId.of("UTC")).toInstant());
+
+    ShowPlanningRivalryDTO rivalry = new ShowPlanningRivalryDTO();
+    rivalry.setId(7L);
+    rivalry.setName("Grudge Match");
+    rivalry.setHeat(15);
+    rivalry.setParticipants(List.of("Alpha", "Beta"));
+    context.setCurrentRivalries(List.of(rivalry));
+
+    when(segmentNarrationService.generateText(anyString())).thenReturn("[]");
+
+    ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+
+    // When
+    showPlanningAiService.planShow(context);
+
+    // Then
+    verify(narrationServiceFactory, times(1)).generateText(promptCaptor.capture());
+    String prompt = promptCaptor.getValue();
+    assertTrue(prompt.contains("- Id: 7"));
+    assertTrue(prompt.contains("Name: Grudge Match"));
+  }
+
+  @Test
+  void planShow_pleContextAddsBookingRulesInPrompt() {
+    // Given
+    ShowPlanningContextDTO context = new ShowPlanningContextDTO();
+    ShowTemplate showTemplate = new ShowTemplate();
+    showTemplate.setExpectedMatches(2);
+    showTemplate.setExpectedPromos(0);
+    context.setShowTemplate(showTemplate);
+    context.setShowDate(
+        LocalDate.of(2025, 4, 6).atStartOfDay(java.time.ZoneId.of("UTC")).toInstant());
+    context.setPremiumLiveEvent(true);
+
+    when(segmentNarrationService.generateText(anyString())).thenReturn("[]");
+
+    ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+
+    // When
+    showPlanningAiService.planShow(context);
+
+    // Then
+    verify(narrationServiceFactory, times(1)).generateText(promptCaptor.capture());
+    String prompt = promptCaptor.getValue();
+    assertTrue(prompt.contains("THIS IS A PREMIUM LIVE EVENT (PLE)"));
+    assertTrue(prompt.contains("PLE-Specific Booking Rules"));
+    assertTrue(prompt.contains("ALL rivalries at Heat"));
+  }
+
+  @Test
+  void planShow_nonPleContextOmitsPleBookingRules() {
+    // Given
+    ShowPlanningContextDTO context = new ShowPlanningContextDTO();
+    ShowTemplate showTemplate = new ShowTemplate();
+    showTemplate.setExpectedMatches(2);
+    showTemplate.setExpectedPromos(0);
+    context.setShowTemplate(showTemplate);
+    context.setShowDate(
+        LocalDate.of(2025, 4, 6).atStartOfDay(java.time.ZoneId.of("UTC")).toInstant());
+    context.setPremiumLiveEvent(false);
+
+    when(segmentNarrationService.generateText(anyString())).thenReturn("[]");
+
+    ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+
+    // When
+    showPlanningAiService.planShow(context);
+
+    // Then
+    verify(narrationServiceFactory, times(1)).generateText(promptCaptor.capture());
+    String prompt = promptCaptor.getValue();
+    assertFalse(prompt.contains("THIS IS A PREMIUM LIVE EVENT (PLE)"));
+    assertFalse(prompt.contains("PLE-Specific Booking Rules"));
+  }
 }

--- a/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningAiServiceTest.java
@@ -398,4 +398,130 @@ class ShowPlanningAiServiceTest {
     assertFalse(prompt.contains("THIS IS A PREMIUM LIVE EVENT (PLE)"));
     assertFalse(prompt.contains("PLE-Specific Booking Rules"));
   }
+
+  @Test
+  void planShow_rivalryClassifiedAsMustBook_whenHeatBetween10And19() {
+    // Given
+    ShowPlanningContextDTO context = new ShowPlanningContextDTO();
+    ShowTemplate showTemplate = new ShowTemplate();
+    showTemplate.setExpectedMatches(1);
+    showTemplate.setExpectedPromos(0);
+    context.setShowTemplate(showTemplate);
+    context.setShowDate(
+        LocalDate.of(2025, 6, 1).atStartOfDay(java.time.ZoneId.of("UTC")).toInstant());
+
+    ShowPlanningRivalryDTO rivalry = new ShowPlanningRivalryDTO();
+    rivalry.setId(1L);
+    rivalry.setName("Brewing Feud");
+    rivalry.setHeat(15);
+    rivalry.setParticipants(List.of("Alpha", "Beta"));
+    context.setCurrentRivalries(List.of(rivalry));
+
+    when(segmentNarrationService.generateText(anyString())).thenReturn("[]");
+
+    ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+    showPlanningAiService.planShow(context);
+
+    verify(narrationServiceFactory, times(1)).generateText(promptCaptor.capture());
+    String prompt = promptCaptor.getValue();
+    assertTrue(prompt.contains("Classification: MUST_BOOK"));
+  }
+
+  @Test
+  void planShow_rivalryClassifiedAsPleResolutionEligible_whenHeatBetween20And29() {
+    // Given
+    ShowPlanningContextDTO context = new ShowPlanningContextDTO();
+    ShowTemplate showTemplate = new ShowTemplate();
+    showTemplate.setExpectedMatches(1);
+    showTemplate.setExpectedPromos(0);
+    context.setShowTemplate(showTemplate);
+    context.setShowDate(
+        LocalDate.of(2025, 6, 1).atStartOfDay(java.time.ZoneId.of("UTC")).toInstant());
+
+    ShowPlanningRivalryDTO rivalry = new ShowPlanningRivalryDTO();
+    rivalry.setId(2L);
+    rivalry.setName("Hot Feud");
+    rivalry.setHeat(25);
+    rivalry.setParticipants(List.of("Gamma", "Delta"));
+    context.setCurrentRivalries(List.of(rivalry));
+
+    when(segmentNarrationService.generateText(anyString())).thenReturn("[]");
+
+    ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+    showPlanningAiService.planShow(context);
+
+    verify(narrationServiceFactory, times(1)).generateText(promptCaptor.capture());
+    String prompt = promptCaptor.getValue();
+    assertTrue(prompt.contains("Classification: PLE_RESOLUTION_ELIGIBLE"));
+  }
+
+  @Test
+  void planShow_rivalryClassifiedAsStipulationRequired_whenHeatAtOrAbove30() {
+    // Given
+    ShowPlanningContextDTO context = new ShowPlanningContextDTO();
+    ShowTemplate showTemplate = new ShowTemplate();
+    showTemplate.setExpectedMatches(1);
+    showTemplate.setExpectedPromos(0);
+    context.setShowTemplate(showTemplate);
+    context.setShowDate(
+        LocalDate.of(2025, 6, 1).atStartOfDay(java.time.ZoneId.of("UTC")).toInstant());
+
+    ShowPlanningRivalryDTO rivalry = new ShowPlanningRivalryDTO();
+    rivalry.setId(3L);
+    rivalry.setName("Blood Feud");
+    rivalry.setHeat(35);
+    rivalry.setParticipants(List.of("Epsilon", "Zeta"));
+    context.setCurrentRivalries(List.of(rivalry));
+
+    when(segmentNarrationService.generateText(anyString())).thenReturn("[]");
+
+    ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+    showPlanningAiService.planShow(context);
+
+    verify(narrationServiceFactory, times(1)).generateText(promptCaptor.capture());
+    String prompt = promptCaptor.getValue();
+    assertTrue(prompt.contains("Classification: STIPULATION_REQUIRED"));
+  }
+
+  @Test
+  void planShow_promptOmitsWrestlerHeatSection() {
+    // Given
+    ShowPlanningContextDTO context = new ShowPlanningContextDTO();
+    ShowTemplate showTemplate = new ShowTemplate();
+    showTemplate.setExpectedMatches(1);
+    showTemplate.setExpectedPromos(0);
+    context.setShowTemplate(showTemplate);
+    context.setShowDate(
+        LocalDate.of(2025, 6, 1).atStartOfDay(java.time.ZoneId.of("UTC")).toInstant());
+
+    when(segmentNarrationService.generateText(anyString())).thenReturn("[]");
+
+    ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+    showPlanningAiService.planShow(context);
+
+    verify(narrationServiceFactory, times(1)).generateText(promptCaptor.capture());
+    String prompt = promptCaptor.getValue();
+    assertFalse(prompt.contains("Wrestler Heat:"));
+  }
+
+  @Test
+  void planShow_promptOmitsRecentPromosSection() {
+    // Given
+    ShowPlanningContextDTO context = new ShowPlanningContextDTO();
+    ShowTemplate showTemplate = new ShowTemplate();
+    showTemplate.setExpectedMatches(1);
+    showTemplate.setExpectedPromos(0);
+    context.setShowTemplate(showTemplate);
+    context.setShowDate(
+        LocalDate.of(2025, 6, 1).atStartOfDay(java.time.ZoneId.of("UTC")).toInstant());
+
+    when(segmentNarrationService.generateText(anyString())).thenReturn("[]");
+
+    ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+    showPlanningAiService.planShow(context);
+
+    verify(narrationServiceFactory, times(1)).generateText(promptCaptor.capture());
+    String prompt = promptCaptor.getValue();
+    assertFalse(prompt.contains("Recent Promos"));
+  }
 }

--- a/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningServiceIT.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
-import com.github.javydreamercsw.base.domain.wrestler.WrestlerTier;
 import com.github.javydreamercsw.management.ManagementIntegrationTest;
 import com.github.javydreamercsw.management.domain.rivalry.Rivalry;
 import com.github.javydreamercsw.management.domain.show.Show;
@@ -33,7 +32,6 @@ import com.github.javydreamercsw.management.domain.show.type.ShowType;
 import com.github.javydreamercsw.management.domain.title.Title;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
-import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.service.faction.FactionService;
 import com.github.javydreamercsw.management.service.rivalry.RivalryService;
 import com.github.javydreamercsw.management.service.segment.SegmentService;
@@ -404,7 +402,7 @@ class ShowPlanningServiceIT extends ManagementIntegrationTest {
 
   @Test
   @WithMockUser(roles = "BOOKER")
-  void getShowPlanningContext_shouldIncludeWrestlerHeats() {
+  void getShowPlanningContext_shouldFilterRivalriesBelowHeat10() {
     // Given
     Show show = mock(Show.class);
     when(show.getName()).thenReturn("Test Show");
@@ -417,54 +415,33 @@ class ShowPlanningServiceIT extends ManagementIntegrationTest {
     showType.setExpectedPromos(3);
     when(show.getType()).thenReturn(showType);
 
-    // Create wrestlers with rivalries
     Wrestler wrestler1 = Wrestler.builder().build();
     wrestler1.setId(1L);
     wrestler1.setName("Wrestler 1");
-
     Wrestler wrestler2 = Wrestler.builder().build();
     wrestler2.setId(2L);
     wrestler2.setName("Wrestler 2");
-
     Wrestler wrestler3 = Wrestler.builder().build();
     wrestler3.setId(3L);
     wrestler3.setName("Wrestler 3");
 
-    Wrestler wrestler4 = Wrestler.builder().build();
-    wrestler4.setId(4L);
-    wrestler4.setName("Wrestler 4");
+    Rivalry hotRivalry = new Rivalry();
+    hotRivalry.setId(1L);
+    hotRivalry.setWrestler1(wrestler1);
+    hotRivalry.setWrestler2(wrestler2);
+    hotRivalry.setHeat(15);
 
-    // Create rivalries
-    Rivalry rivalry1 = new Rivalry();
-    rivalry1.setId(1L);
-    rivalry1.setWrestler1(wrestler1);
-    rivalry1.setWrestler2(wrestler2);
-    rivalry1.setHeat(75);
+    Rivalry coldRivalry = new Rivalry();
+    coldRivalry.setId(2L);
+    coldRivalry.setWrestler1(wrestler1);
+    coldRivalry.setWrestler2(wrestler3);
+    coldRivalry.setHeat(5);
 
-    Rivalry rivalry2 = new Rivalry();
-    rivalry2.setId(2L);
-    rivalry2.setWrestler1(wrestler1);
-    rivalry2.setWrestler2(wrestler3);
-    rivalry2.setHeat(50);
-
-    // Mock the wrestler service to return our wrestlers
+    when(rivalryService.getActiveRivalries()).thenReturn(Arrays.asList(hotRivalry, coldRivalry));
     when(wrestlerService.findAllFiltered(any(), any(), anyLong(), (String) any(), any()))
-        .thenReturn(Arrays.asList(wrestler1, wrestler2, wrestler3, wrestler4));
-
-    // Mock the rivalry service to return appropriate rivalries for each wrestler
-    when(rivalryService.getRivalriesForWrestler(1L)).thenReturn(Arrays.asList(rivalry1, rivalry2));
-    when(rivalryService.getRivalriesForWrestler(2L))
-        .thenReturn(Collections.singletonList(rivalry1));
-    when(rivalryService.getRivalriesForWrestler(3L))
-        .thenReturn(Collections.singletonList(rivalry2));
-    when(rivalryService.getRivalriesForWrestler(4L)).thenReturn(Collections.emptyList());
-
-    // Mock other dependencies
+        .thenReturn(Collections.emptyList());
     when(segmentRepository.findBySegmentDateBetween(any(), any()))
         .thenReturn(Collections.emptyList());
-    when(rivalryService.getActiveRivalriesBetween(any(), any()))
-        .thenReturn(Collections.emptyList());
-    when(promoBookingService.isPromoSegment(any())).thenReturn(false);
     when(titleService.getActiveTitles()).thenReturn(Collections.emptyList());
     when(segmentService.findById(anyLong())).thenReturn(Optional.empty());
     when(factionService.findAll()).thenReturn(Collections.emptyList());
@@ -472,91 +449,10 @@ class ShowPlanningServiceIT extends ManagementIntegrationTest {
     // Act
     ShowPlanningContextDTO context = showPlanningService.getShowPlanningContext(show);
 
-    // Assert
+    // Assert: only the rivalry with heat >= 10 survives the mapper filter
     assertNotNull(context);
-    assertNotNull(context.getWrestlerHeats(), "Wrestler heats should not be null");
-    assertFalse(context.getWrestlerHeats().isEmpty(), "Wrestler heats should not be empty");
-
-    // Should have 4 heat entries total (2 for wrestler1, 1 for wrestler2, 1 for wrestler3)
-    assertEquals(
-        4,
-        context.getWrestlerHeats().size(),
-        "Should have 4 wrestler heat entries: " + context.getWrestlerHeats());
-
-    // Verify wrestler1's heats
-    long wrestler1Heats =
-        context.getWrestlerHeats().stream()
-            .filter(h -> "Wrestler 1".equals(h.getWrestlerName()))
-            .count();
-    assertEquals(2, wrestler1Heats, "Wrestler 1 should have 2 feuds");
-
-    // Verify specific heat values
-    assertTrue(
-        context.getWrestlerHeats().stream()
-            .anyMatch(
-                h ->
-                    "Wrestler 1".equals(h.getWrestlerName())
-                        && "Wrestler 2".equals(h.getOpponentName())
-                        && h.getHeat() == 75),
-        "Should have heat entry for Wrestler 1 vs Wrestler 2 with heat 75");
-
-    assertTrue(
-        context.getWrestlerHeats().stream()
-            .anyMatch(
-                h ->
-                    "Wrestler 1".equals(h.getWrestlerName())
-                        && "Wrestler 3".equals(h.getOpponentName())
-                        && h.getHeat() == 50),
-        "Should have heat entry for Wrestler 1 vs Wrestler 3 with heat 50");
-  }
-
-  @Test
-  @WithMockUser(roles = "BOOKER")
-  void getShowPlanningContext_shouldHandleWrestlersWithNoRivalries() {
-    // Given
-    Show show = mock(Show.class);
-    when(show.getName()).thenReturn("Test Show");
-    when(show.getShowDate()).thenReturn(LocalDate.now());
-    when(show.getId()).thenReturn(1L);
-    when(show.getUniverse()).thenReturn(universe);
-    ShowType showType = new ShowType();
-    showType.setName("Regular Show Type");
-    showType.setExpectedMatches(5);
-    showType.setExpectedPromos(3);
-    when(show.getType()).thenReturn(showType);
-
-    // Create wrestlers with no rivalries
-    Wrestler wrestler1 = Wrestler.builder().build();
-    wrestler1.setId(1L);
-    wrestler1.setName("Wrestler 1");
-    WrestlerState state = WrestlerState.builder().tier(WrestlerTier.MAIN_EVENTER).build();
-    wrestler1.getWrestlerStates().add(state);
-
-    // Mock the wrestler service to return our wrestler
-    when(wrestlerService.findAllFiltered(any(), any(), anyLong(), (String) any(), any()))
-        .thenReturn(Collections.singletonList(wrestler1));
-
-    // Mock the rivalry service to return empty list (no rivalries)
-    when(rivalryService.getRivalriesForWrestler(1L)).thenReturn(Collections.emptyList());
-
-    // Mock other dependencies
-    when(segmentRepository.findBySegmentDateBetween(any(), any()))
-        .thenReturn(Collections.emptyList());
-    when(rivalryService.getActiveRivalriesBetween(any(), any()))
-        .thenReturn(Collections.emptyList());
-    when(promoBookingService.isPromoSegment(any())).thenReturn(false);
-    when(titleService.getActiveTitles()).thenReturn(Collections.emptyList());
-    when(segmentService.findById(anyLong())).thenReturn(Optional.empty());
-    when(factionService.findAll()).thenReturn(Collections.emptyList());
-
-    // Act
-    ShowPlanningContextDTO context = showPlanningService.getShowPlanningContext(show);
-
-    // Assert
-    assertNotNull(context);
-    assertNotNull(context.getWrestlerHeats(), "Wrestler heats should not be null");
-    assertTrue(
-        context.getWrestlerHeats().isEmpty(),
-        "Wrestler heats should be empty when no rivalries exist");
+    assertNotNull(context.getCurrentRivalries());
+    assertEquals(1, context.getCurrentRivalries().size());
+    assertEquals(15, context.getCurrentRivalries().get(0).getHeat());
   }
 }

--- a/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningServiceTest.java
@@ -40,7 +40,6 @@ import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.service.segment.SegmentSummaryService;
 import com.github.javydreamercsw.management.service.segment.type.SegmentTypeService;
-import com.github.javydreamercsw.management.service.show.PromoBookingService;
 import com.github.javydreamercsw.management.service.show.planning.dto.ShowPlanningContextDTO;
 import com.github.javydreamercsw.management.service.wrestler.WrestlerService;
 import java.time.Clock;
@@ -79,7 +78,6 @@ class ShowPlanningServiceTest {
   @Mock private com.github.javydreamercsw.management.service.show.ShowService showService;
   @Mock private SegmentSummaryService segmentSummaryService;
   @Mock private com.github.javydreamercsw.management.service.segment.SegmentService segmentService;
-  @Mock private PromoBookingService promoBookingService;
   @Mock private com.github.javydreamercsw.management.service.npc.NpcService npcService;
   @Mock private org.springframework.context.ApplicationEventPublisher eventPublisher;
   @Mock private Clock clock;
@@ -193,7 +191,6 @@ class ShowPlanningServiceTest {
     when(wrestlerService.findAllFiltered(any(), any(), anyLong(), (String) any(), any()))
         .thenReturn(List.of(activeWrestler));
     when(rivalryService.getActiveRivalries()).thenReturn(new ArrayList<>());
-    when(rivalryService.getRivalriesForWrestler(anyLong())).thenReturn(new ArrayList<>());
     when(titleService.getActiveTitles()).thenReturn(new ArrayList<>());
     when(factionService.findAll()).thenReturn(new ArrayList<>());
     when(showService.getUpcomingShows(10)).thenReturn(new ArrayList<>());
@@ -287,7 +284,6 @@ class ShowPlanningServiceTest {
     when(wrestlerService.findAllFiltered(any(), any(), anyLong(), (String) any(), any()))
         .thenReturn(List.of(activeWrestler));
     when(rivalryService.getActiveRivalries()).thenReturn(new ArrayList<>());
-    when(rivalryService.getRivalriesForWrestler(anyLong())).thenReturn(new ArrayList<>());
     when(titleService.getActiveTitles()).thenReturn(new ArrayList<>());
     when(factionService.findAll()).thenReturn(new ArrayList<>());
     when(showService.getUpcomingShows(10)).thenReturn(new ArrayList<>());
@@ -311,7 +307,6 @@ class ShowPlanningServiceTest {
     when(wrestlerService.findAllFiltered(any(), any(), anyLong(), (String) any(), any()))
         .thenReturn(List.of(activeWrestler));
     when(rivalryService.getActiveRivalries()).thenReturn(new ArrayList<>());
-    when(rivalryService.getRivalriesForWrestler(anyLong())).thenReturn(new ArrayList<>());
     when(titleService.getActiveTitles()).thenReturn(new ArrayList<>());
     when(factionService.findAll()).thenReturn(new ArrayList<>());
     when(showService.getUpcomingShows(10)).thenReturn(new ArrayList<>());

--- a/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningServiceTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.github.javydreamercsw.management.domain.rivalry.Rivalry;
 import com.github.javydreamercsw.management.domain.show.Show;
 import com.github.javydreamercsw.management.domain.show.segment.Segment;
 import com.github.javydreamercsw.management.domain.show.segment.SegmentRepository;
@@ -321,5 +322,110 @@ class ShowPlanningServiceTest {
     // Then
     verify(mapper).toDto(contextCaptor.capture());
     assertFalse(contextCaptor.getValue().isPremiumLiveEvent());
+  }
+
+  // --- validateCard tests ---
+
+  private Rivalry rivalryWithHeat(long id, String w1Name, String w2Name, int heat) {
+    Wrestler w1 = new Wrestler();
+    w1.setId(id * 10);
+    w1.setName(w1Name);
+    Wrestler w2 = new Wrestler();
+    w2.setId(id * 10 + 1);
+    w2.setName(w2Name);
+    Rivalry rivalry = new Rivalry();
+    rivalry.setId(id);
+    rivalry.setWrestler1(w1);
+    rivalry.setWrestler2(w2);
+    rivalry.setHeat(heat);
+    return rivalry;
+  }
+
+  @Test
+  void validateCard_noActiveRivalries_returnsNoErrors() {
+    List<String> errors = showPlanningService.validateCard(List.of(), List.of());
+    assertTrue(errors.isEmpty());
+  }
+
+  @Test
+  void validateCard_rivalryBelowThreshold_notRequired() {
+    Rivalry cold = rivalryWithHeat(1L, "Alpha", "Beta", 9);
+    List<String> errors = showPlanningService.validateCard(List.of(), List.of(cold));
+    assertTrue(errors.isEmpty());
+  }
+
+  @Test
+  void validateCard_mustBookRivalry_missingFromCard_returnsError() {
+    Rivalry hot = rivalryWithHeat(1L, "Alpha", "Beta", 15);
+    List<String> errors = showPlanningService.validateCard(List.of(), List.of(hot));
+    assertEquals(1, errors.size());
+    assertTrue(errors.get(0).contains("Alpha"));
+    assertTrue(errors.get(0).contains("Beta"));
+    assertTrue(errors.get(0).contains("MUST_BOOK"));
+  }
+
+  @Test
+  void validateCard_mustBookRivalry_bookedByParticipantNames_noError() {
+    Rivalry hot = rivalryWithHeat(1L, "Alpha", "Beta", 15);
+    ProposedSegment seg = new ProposedSegment();
+    seg.setParticipants(List.of("Alpha", "Beta"));
+    List<String> errors = showPlanningService.validateCard(List.of(seg), List.of(hot));
+    assertTrue(errors.isEmpty());
+  }
+
+  @Test
+  void validateCard_mustBookRivalry_bookedByRivalryId_noError() {
+    Rivalry hot = rivalryWithHeat(1L, "Alpha", "Beta", 15);
+    ProposedSegment seg = new ProposedSegment();
+    seg.setParticipants(List.of("Alpha", "Beta"));
+    seg.setRivalryId(1L);
+    List<String> errors = showPlanningService.validateCard(List.of(seg), List.of(hot));
+    assertTrue(errors.isEmpty());
+  }
+
+  @Test
+  void validateCard_stipulationRequired_missingFromCard_returnsError() {
+    Rivalry max = rivalryWithHeat(1L, "Alpha", "Beta", 30);
+    List<String> errors = showPlanningService.validateCard(List.of(), List.of(max));
+    assertEquals(1, errors.size());
+    assertTrue(errors.get(0).contains("MUST_BOOK"));
+  }
+
+  @Test
+  void validateCard_stipulationRequired_bookedWithoutStipulation_returnsError() {
+    Rivalry max = rivalryWithHeat(1L, "Alpha", "Beta", 30);
+    ProposedSegment seg = new ProposedSegment();
+    seg.setParticipants(List.of("Alpha", "Beta"));
+    seg.setRules(List.of());
+    List<String> errors = showPlanningService.validateCard(List.of(seg), List.of(max));
+    assertEquals(1, errors.size());
+    assertTrue(errors.get(0).contains("STIPULATION_REQUIRED"));
+  }
+
+  @Test
+  void validateCard_stipulationRequired_bookedWithStipulation_noError() {
+    Rivalry max = rivalryWithHeat(1L, "Alpha", "Beta", 30);
+    ProposedSegment seg = new ProposedSegment();
+    seg.setParticipants(List.of("Alpha", "Beta"));
+    seg.setRules(List.of("Steel Cage"));
+    List<String> errors = showPlanningService.validateCard(List.of(seg), List.of(max));
+    assertTrue(errors.isEmpty());
+  }
+
+  @Test
+  void approveSegments_withMustBookRivalryMissingFromCard_throws() {
+    Rivalry hot = rivalryWithHeat(1L, "Alpha", "Beta", 15);
+    when(rivalryService.getActiveRivalries()).thenReturn(List.of(hot));
+
+    ProposedSegment seg = new ProposedSegment();
+    seg.setType("Match");
+    seg.setParticipants(List.of("Charlie", "Delta"));
+    SegmentType matchType = new SegmentType();
+    matchType.setName("Match");
+    when(segmentTypeService.findByName("Match")).thenReturn(Optional.of(matchType));
+    when(wrestlerRepository.findByName(any())).thenReturn(Optional.empty());
+
+    assertThrows(
+        IllegalStateException.class, () -> showPlanningService.approveSegments(show, List.of(seg)));
   }
 }

--- a/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/show/planning/ShowPlanningServiceTest.java
@@ -17,6 +17,7 @@
 package com.github.javydreamercsw.management.service.show.planning;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -31,6 +32,7 @@ import com.github.javydreamercsw.management.domain.show.segment.Segment;
 import com.github.javydreamercsw.management.domain.show.segment.SegmentRepository;
 import com.github.javydreamercsw.management.domain.show.segment.rule.SegmentRule;
 import com.github.javydreamercsw.management.domain.show.segment.type.SegmentType;
+import com.github.javydreamercsw.management.domain.show.template.ShowTemplate;
 import com.github.javydreamercsw.management.domain.show.type.ShowType;
 import com.github.javydreamercsw.management.domain.title.Title;
 import com.github.javydreamercsw.management.domain.universe.Universe;
@@ -266,5 +268,63 @@ class ShowPlanningServiceTest {
     // When & Then
     assertThrows(
         IllegalStateException.class, () -> showPlanningService.getShowPlanningContext(show));
+  }
+
+  @Test
+  void testGetShowPlanningContext_PleShowFlagsPropagated() {
+    // Given
+    ShowType pleShowType = new ShowType();
+    pleShowType.setName("Premium Live Event (PLE)");
+
+    ShowTemplate pleTemplate = new ShowTemplate();
+    pleTemplate.setShowType(pleShowType);
+    pleTemplate.setExpectedMatches(5);
+    pleTemplate.setExpectedPromos(2);
+
+    show.setTemplate(pleTemplate);
+
+    when(segmentRepository.findBySegmentDateBetween(any(), any())).thenReturn(new ArrayList<>());
+    when(wrestlerService.findAllFiltered(any(), any(), anyLong(), (String) any(), any()))
+        .thenReturn(List.of(activeWrestler));
+    when(rivalryService.getActiveRivalries()).thenReturn(new ArrayList<>());
+    when(rivalryService.getRivalriesForWrestler(anyLong())).thenReturn(new ArrayList<>());
+    when(titleService.getActiveTitles()).thenReturn(new ArrayList<>());
+    when(factionService.findAll()).thenReturn(new ArrayList<>());
+    when(showService.getUpcomingShows(10)).thenReturn(new ArrayList<>());
+    when(mapper.toDto(any(ShowPlanningContext.class))).thenReturn(new ShowPlanningContextDTO());
+
+    ArgumentCaptor<ShowPlanningContext> contextCaptor =
+        ArgumentCaptor.forClass(ShowPlanningContext.class);
+
+    // When
+    showPlanningService.getShowPlanningContext(show);
+
+    // Then
+    verify(mapper).toDto(contextCaptor.capture());
+    assertTrue(contextCaptor.getValue().isPremiumLiveEvent());
+  }
+
+  @Test
+  void testGetShowPlanningContext_NonPleShowFlagsFalse() {
+    // Given — show has no template, isPremiumLiveEvent() returns false
+    when(segmentRepository.findBySegmentDateBetween(any(), any())).thenReturn(new ArrayList<>());
+    when(wrestlerService.findAllFiltered(any(), any(), anyLong(), (String) any(), any()))
+        .thenReturn(List.of(activeWrestler));
+    when(rivalryService.getActiveRivalries()).thenReturn(new ArrayList<>());
+    when(rivalryService.getRivalriesForWrestler(anyLong())).thenReturn(new ArrayList<>());
+    when(titleService.getActiveTitles()).thenReturn(new ArrayList<>());
+    when(factionService.findAll()).thenReturn(new ArrayList<>());
+    when(showService.getUpcomingShows(10)).thenReturn(new ArrayList<>());
+    when(mapper.toDto(any(ShowPlanningContext.class))).thenReturn(new ShowPlanningContextDTO());
+
+    ArgumentCaptor<ShowPlanningContext> contextCaptor =
+        ArgumentCaptor.forClass(ShowPlanningContext.class);
+
+    // When
+    showPlanningService.getShowPlanningContext(show);
+
+    // Then
+    verify(mapper).toDto(contextCaptor.capture());
+    assertFalse(contextCaptor.getValue().isPremiumLiveEvent());
   }
 }

--- a/src/test/java/com/github/javydreamercsw/management/service/show/planning/dto/ShowPlanningDtoMapperTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/show/planning/dto/ShowPlanningDtoMapperTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import com.github.javydreamercsw.base.domain.wrestler.WrestlerTier;
 import com.github.javydreamercsw.management.domain.show.Show;
 import com.github.javydreamercsw.management.domain.show.segment.Segment;
 import com.github.javydreamercsw.management.domain.show.segment.SegmentParticipant;
@@ -28,7 +29,7 @@ import com.github.javydreamercsw.management.domain.show.segment.rule.SegmentRule
 import com.github.javydreamercsw.management.domain.show.segment.type.PromoType;
 import com.github.javydreamercsw.management.domain.show.segment.type.SegmentType;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
-import com.github.javydreamercsw.management.service.show.planning.ShowPlanningWrestlerHeat;
+import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,6 +46,7 @@ class ShowPlanningDtoMapperTest {
 
   @InjectMocks private ShowPlanningDtoMapper mapper;
 
+  @Mock private com.github.javydreamercsw.management.service.show.ShowService showService;
   @Mock private Segment segment;
   @Mock private Show show;
   @Mock private SegmentType segmentType;
@@ -164,56 +166,56 @@ class ShowPlanningDtoMapperTest {
   }
 
   @Test
-  void toDto_wrestlerHeat_mapsCorrectly() {
+  void toRosterEntryDto_mapsNameAndGender() {
     // Given
-    ShowPlanningWrestlerHeat heat = new ShowPlanningWrestlerHeat();
-    heat.setWrestlerName("Wrestler One");
-    heat.setOpponentName("Wrestler Two");
-    heat.setHeat(75);
+    com.github.javydreamercsw.management.domain.wrestler.Wrestler wrestler =
+        com.github.javydreamercsw.management.domain.wrestler.Wrestler.builder().build();
+    wrestler.setName("John Doe");
+    wrestler.setGender(com.github.javydreamercsw.base.domain.wrestler.Gender.MALE);
 
     // When
-    ShowPlanningWrestlerHeatDTO dto = mapper.toDto(heat);
+    ShowPlanningRosterEntryDTO dto = mapper.toRosterEntryDto(wrestler);
 
     // Then
     assertNotNull(dto);
-    assertEquals("Wrestler One", dto.getWrestlerName());
-    assertEquals("Wrestler Two", dto.getOpponentName());
-    assertEquals(75, dto.getHeat());
+    assertEquals("John Doe", dto.getName());
+    assertEquals("MALE", dto.getGender());
   }
 
   @Test
-  void toDto_wrestlerHeatWithZeroHeat_mapsCorrectly() {
+  void toRosterEntryDto_withDefaultState_mapsTierAndFans() {
     // Given
-    ShowPlanningWrestlerHeat heat = new ShowPlanningWrestlerHeat();
-    heat.setWrestlerName("Wrestler One");
-    heat.setOpponentName("Wrestler Two");
-    heat.setHeat(0);
+    com.github.javydreamercsw.management.domain.wrestler.Wrestler wrestler =
+        com.github.javydreamercsw.management.domain.wrestler.Wrestler.builder().build();
+    wrestler.setName("Main Eventer");
+    wrestler.setGender(com.github.javydreamercsw.base.domain.wrestler.Gender.FEMALE);
+    WrestlerState state = WrestlerState.builder().tier(WrestlerTier.MAIN_EVENTER).build();
+    state.setFans(5000L);
+    wrestler.getWrestlerStates().add(state);
 
     // When
-    ShowPlanningWrestlerHeatDTO dto = mapper.toDto(heat);
+    ShowPlanningRosterEntryDTO dto = mapper.toRosterEntryDto(wrestler);
 
     // Then
     assertNotNull(dto);
-    assertEquals("Wrestler One", dto.getWrestlerName());
-    assertEquals("Wrestler Two", dto.getOpponentName());
-    assertEquals(0, dto.getHeat());
+    assertEquals("Main Eventer", dto.getName());
+    assertEquals("FEMALE", dto.getGender());
+    assertEquals(WrestlerTier.MAIN_EVENTER, dto.getTier());
+    assertEquals(5000L, dto.getFans());
   }
 
   @Test
-  void toDto_wrestlerHeatWithHighHeat_mapsCorrectly() {
+  void toRosterEntryDto_nullGender_defaultsMale() {
     // Given
-    ShowPlanningWrestlerHeat heat = new ShowPlanningWrestlerHeat();
-    heat.setWrestlerName("Main Eventer");
-    heat.setOpponentName("Top Heel");
-    heat.setHeat(100);
+    com.github.javydreamercsw.management.domain.wrestler.Wrestler wrestler =
+        com.github.javydreamercsw.management.domain.wrestler.Wrestler.builder().build();
+    wrestler.setName("Unknown");
+    wrestler.setGender(null);
 
     // When
-    ShowPlanningWrestlerHeatDTO dto = mapper.toDto(heat);
+    ShowPlanningRosterEntryDTO dto = mapper.toRosterEntryDto(wrestler);
 
     // Then
-    assertNotNull(dto);
-    assertEquals("Main Eventer", dto.getWrestlerName());
-    assertEquals("Top Heel", dto.getOpponentName());
-    assertEquals(100, dto.getHeat());
+    assertEquals("MALE", dto.getGender());
   }
 }


### PR DESCRIPTION
Summary
  
  - ATW-5lb / ATW-6d2: Added rivalryId to ProposedSegment and isPLE flag to ShowPlanningContext so AI-booked segments carry explicit rivalry linkage through the approval flow.
  - ATW-f5u: Reduced AI prompt noise — filter rivalries below heat 10, trim full roster to lean booking-relevant fields (ShowPlanningRosterEntryDTO), remove redundant wrestlerHeats and recentPromos sections. Added classification labels (MUST_BOOK / PLE_RESOLUTION_ELIGIBLE / STIPULATION_REQUIRED) with instructions to the AI on how to handle each tier.
  - ATW-tdt: When a segment has a rivalryId set by the AI, boost that rivalry's heat at adjudication time (+2 regular show, +3 PLE) and attempt resolution directly on PLE shows instead of falling back to generic wrestler-pair scanning. Schema migration adds rivalry_id column to segment (H2 V80 / MySQL V48).
  - ATW-6i8: ShowPlanningService.validateCard() gates approveSegments() — MUST_BOOK rivalries must appear on the card, STIPULATION_REQUIRED rivalries must be booked with at least one match rule. Throws IllegalStateException on violations.

  Test plan

  - ShowPlanningAiServiceTest — rivalry classification labels in prompt
  - ShowPlanningServiceTest — validateCard() permutations (missing, booked by name, booked by id, stipulation required/missing)
  - SegmentAdjudicationServiceTest — targeted heat on regular/PLE show, targeted resolution on PLE, null-rivalryId fallback to pair scan
  - ShowPlanningServiceIT — rivalry heat filter (heat < 10 excluded from context)
