### PR TITLE
test(ATW-8a4): add unit tests for missing Notion sync outgoing services

### DIFF
--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/FactionNotionSyncServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/FactionNotionSyncServiceTest.java
@@ -1,0 +1,129 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.sync.entity.notion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.management.domain.faction.Faction;
+import com.github.javydreamercsw.management.service.sync.AbstractSyncTest;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import notion.api.v1.NotionClient;
+import notion.api.v1.model.pages.Page;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+class FactionNotionSyncServiceTest extends AbstractSyncTest {
+
+  private FactionNotionSyncService factionNotionSyncService;
+  @Captor private ArgumentCaptor<Faction> factionCaptor;
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+    factionNotionSyncService =
+        new FactionNotionSyncService(factionRepository, syncServiceDependencies, notionApiExecutor);
+  }
+
+  @Test
+  @DisplayName("Sync new faction creates Notion page and saves external ID")
+  void syncToNotion_newFaction_createsPageAndSavesExternalId() {
+    String operationId = UUID.randomUUID().toString();
+
+    Faction faction = new Faction();
+    faction.setName("The Order");
+    faction.setAlignment("HEEL");
+    faction.setDescription("Villainous stable");
+
+    NotionClient client = mock(NotionClient.class);
+    when(factionRepository.findAll()).thenReturn(List.of(faction));
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_factions");
+
+    Page page = mock(Page.class);
+    when(page.getId()).thenReturn(UUID.randomUUID().toString());
+    when(notionHandler.executeWithRetry(any())).thenReturn(page);
+
+    var result = factionNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(1, result.getCreatedCount());
+    assertEquals(0, result.getErrorCount());
+    verify(factionRepository, times(1)).saveAndFlush(factionCaptor.capture());
+    assertNotNull(factionCaptor.getValue().getExternalId());
+  }
+
+  @Test
+  @DisplayName("Sync with no factions returns zero counts")
+  void syncToNotion_empty_returnsZeroCounts() {
+    String operationId = UUID.randomUUID().toString();
+
+    NotionClient client = mock(NotionClient.class);
+    when(factionRepository.findAll()).thenReturn(Collections.emptyList());
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_factions");
+
+    var result = factionNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(0, result.getCreatedCount());
+    assertEquals(0, result.getUpdatedCount());
+    assertEquals(0, result.getErrorCount());
+  }
+
+  @Test
+  @DisplayName("Faction with optional leader relation synced without error")
+  void syncToNotion_factionWithLeader_syncedSuccessfully() {
+    String operationId = UUID.randomUUID().toString();
+
+    com.github.javydreamercsw.management.domain.wrestler.Wrestler leader =
+        new com.github.javydreamercsw.management.domain.wrestler.Wrestler();
+    leader.setName("Faction Leader");
+    leader.setExternalId(UUID.randomUUID().toString());
+
+    Faction faction = new Faction();
+    faction.setName("The Coalition");
+    faction.setAlignment("FACE");
+    faction.setLeader(leader);
+
+    NotionClient client = mock(NotionClient.class);
+    when(factionRepository.findAll()).thenReturn(List.of(faction));
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_factions");
+
+    Page page = mock(Page.class);
+    when(page.getId()).thenReturn(UUID.randomUUID().toString());
+    when(notionHandler.executeWithRetry(any())).thenReturn(page);
+
+    var result = factionNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(1, result.getCreatedCount());
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/NpcNotionSyncServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/NpcNotionSyncServiceTest.java
@@ -1,0 +1,124 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.sync.entity.notion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.management.domain.npc.Npc;
+import com.github.javydreamercsw.management.service.sync.AbstractSyncTest;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import notion.api.v1.NotionClient;
+import notion.api.v1.model.pages.Page;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+class NpcNotionSyncServiceTest extends AbstractSyncTest {
+
+  private NpcNotionSyncService npcNotionSyncService;
+  @Captor private ArgumentCaptor<Npc> npcCaptor;
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+    npcNotionSyncService =
+        new NpcNotionSyncService(npcRepository, syncServiceDependencies, notionApiExecutor);
+  }
+
+  @Test
+  @DisplayName("Sync new NPC creates Notion page and saves external ID")
+  void syncToNotion_newNpc_createsPageAndSavesExternalId() {
+    String operationId = UUID.randomUUID().toString();
+
+    Npc npc = new Npc();
+    npc.setName("Test Referee");
+    npc.setNpcType("Referee");
+
+    NotionClient client = mock(NotionClient.class);
+    when(npcRepository.findAll()).thenReturn(List.of(npc));
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_npcs");
+
+    Page page = mock(Page.class);
+    when(page.getId()).thenReturn(UUID.randomUUID().toString());
+    when(notionHandler.executeWithRetry(any())).thenReturn(page);
+
+    var result = npcNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(1, result.getCreatedCount());
+    assertEquals(0, result.getErrorCount());
+    verify(npcRepository, times(1)).saveAndFlush(npcCaptor.capture());
+    assertNotNull(npcCaptor.getValue().getExternalId());
+  }
+
+  @Test
+  @DisplayName("Sync with no NPCs returns zero counts")
+  void syncToNotion_empty_returnsZeroCounts() {
+    String operationId = UUID.randomUUID().toString();
+
+    NotionClient client = mock(NotionClient.class);
+    when(npcRepository.findAll()).thenReturn(Collections.emptyList());
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_npcs");
+
+    var result = npcNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(0, result.getCreatedCount());
+    assertEquals(0, result.getUpdatedCount());
+    assertEquals(0, result.getErrorCount());
+  }
+
+  @Test
+  @DisplayName("NPC with attributes maps them to Notion properties")
+  void syncToNotion_npcWithAttributes_syncedSuccessfully() {
+    String operationId = UUID.randomUUID().toString();
+
+    Npc npc = new Npc();
+    npc.setName("Special Referee");
+    npc.setNpcType("Referee");
+    npc.getAttributes().put("likeness", "Veteran official");
+    npc.getAttributes().put("catchphrase", "Ring the bell!");
+
+    NotionClient client = mock(NotionClient.class);
+    when(npcRepository.findAll()).thenReturn(List.of(npc));
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_npcs");
+
+    Page page = mock(Page.class);
+    when(page.getId()).thenReturn(UUID.randomUUID().toString());
+    when(notionHandler.executeWithRetry(any())).thenReturn(page);
+
+    var result = npcNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(1, result.getCreatedCount());
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/TeamNotionSyncServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/TeamNotionSyncServiceTest.java
@@ -1,0 +1,133 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.sync.entity.notion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.management.domain.team.Team;
+import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
+import com.github.javydreamercsw.management.service.sync.AbstractSyncTest;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import notion.api.v1.NotionClient;
+import notion.api.v1.model.pages.Page;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+class TeamNotionSyncServiceTest extends AbstractSyncTest {
+
+  private TeamNotionSyncService teamNotionSyncService;
+  @Captor private ArgumentCaptor<Team> teamCaptor;
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+    teamNotionSyncService =
+        new TeamNotionSyncService(teamRepository, syncServiceDependencies, notionApiExecutor);
+  }
+
+  @Test
+  @DisplayName("Sync new team creates Notion page and saves external ID")
+  void syncToNotion_newTeam_createsPageAndSavesExternalId() {
+    String operationId = UUID.randomUUID().toString();
+
+    Wrestler w1 = new Wrestler();
+    w1.setName("Partner A");
+    w1.setExternalId(UUID.randomUUID().toString());
+
+    Wrestler w2 = new Wrestler();
+    w2.setName("Partner B");
+    w2.setExternalId(UUID.randomUUID().toString());
+
+    Team team = new Team();
+    team.setName("The Tag Champs");
+    team.setWrestler1(w1);
+    team.setWrestler2(w2);
+
+    NotionClient client = mock(NotionClient.class);
+    when(teamRepository.findAll()).thenReturn(List.of(team));
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_teams");
+
+    Page page = mock(Page.class);
+    when(page.getId()).thenReturn(UUID.randomUUID().toString());
+    when(notionHandler.executeWithRetry(any())).thenReturn(page);
+
+    var result = teamNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(1, result.getCreatedCount());
+    assertEquals(0, result.getErrorCount());
+    verify(teamRepository, times(1)).saveAndFlush(teamCaptor.capture());
+    assertNotNull(teamCaptor.getValue().getExternalId());
+  }
+
+  @Test
+  @DisplayName("Sync with no teams returns zero counts")
+  void syncToNotion_empty_returnsZeroCounts() {
+    String operationId = UUID.randomUUID().toString();
+
+    NotionClient client = mock(NotionClient.class);
+    when(teamRepository.findAll()).thenReturn(Collections.emptyList());
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_teams");
+
+    var result = teamNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(0, result.getCreatedCount());
+    assertEquals(0, result.getUpdatedCount());
+    assertEquals(0, result.getErrorCount());
+  }
+
+  @Test
+  @DisplayName("Team with optional finisher and theme song synced without error")
+  void syncToNotion_teamWithOptionalFields_syncedSuccessfully() {
+    String operationId = UUID.randomUUID().toString();
+
+    Team team = new Team();
+    team.setName("The Express");
+    team.setThemeSong("All Aboard");
+    team.setTeamFinisher("Train Wreck");
+
+    NotionClient client = mock(NotionClient.class);
+    when(teamRepository.findAll()).thenReturn(List.of(team));
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_teams");
+
+    Page page = mock(Page.class);
+    when(page.getId()).thenReturn(UUID.randomUUID().toString());
+    when(notionHandler.executeWithRetry(any())).thenReturn(page);
+
+    var result = teamNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(1, result.getCreatedCount());
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/TitleNotionSyncServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/TitleNotionSyncServiceTest.java
@@ -1,0 +1,124 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.sync.entity.notion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.management.domain.title.Title;
+import com.github.javydreamercsw.management.service.sync.AbstractSyncTest;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import notion.api.v1.NotionClient;
+import notion.api.v1.model.pages.Page;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+class TitleNotionSyncServiceTest extends AbstractSyncTest {
+
+  private TitleNotionSyncService titleNotionSyncService;
+  @Captor private ArgumentCaptor<Title> titleCaptor;
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+    titleNotionSyncService =
+        new TitleNotionSyncService(titleRepository, syncServiceDependencies, notionApiExecutor);
+  }
+
+  @Test
+  @DisplayName("Sync new title creates Notion page and saves external ID")
+  void syncToNotion_newTitle_createsPageAndSavesExternalId() {
+    String operationId = UUID.randomUUID().toString();
+
+    Title title = new Title();
+    title.setName("World Championship");
+    title.setIsActive(true);
+
+    NotionClient client = mock(NotionClient.class);
+    when(titleRepository.findAll()).thenReturn(List.of(title));
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_championships");
+
+    Page page = mock(Page.class);
+    when(page.getId()).thenReturn(UUID.randomUUID().toString());
+    when(notionHandler.executeWithRetry(any())).thenReturn(page);
+
+    var result = titleNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(1, result.getCreatedCount());
+    assertEquals(0, result.getErrorCount());
+    verify(titleRepository, times(1)).saveAndFlush(titleCaptor.capture());
+    assertNotNull(titleCaptor.getValue().getExternalId());
+  }
+
+  @Test
+  @DisplayName("Sync with no titles returns zero counts")
+  void syncToNotion_empty_returnsZeroCounts() {
+    String operationId = UUID.randomUUID().toString();
+
+    NotionClient client = mock(NotionClient.class);
+    when(titleRepository.findAll()).thenReturn(Collections.emptyList());
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_championships");
+
+    var result = titleNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(0, result.getCreatedCount());
+    assertEquals(0, result.getUpdatedCount());
+    assertEquals(0, result.getErrorCount());
+  }
+
+  @Test
+  @DisplayName("Title with optional fields synced without error")
+  void syncToNotion_titleWithOptionalFields_syncedSuccessfully() {
+    String operationId = UUID.randomUUID().toString();
+
+    Title title = new Title();
+    title.setName("Intercontinental Championship");
+    title.setIsActive(true);
+    title.setDescription("Mid-card title");
+    title.setDefenseFrequency(4);
+
+    NotionClient client = mock(NotionClient.class);
+    when(titleRepository.findAll()).thenReturn(List.of(title));
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_championships");
+
+    Page page = mock(Page.class);
+    when(page.getId()).thenReturn(UUID.randomUUID().toString());
+    when(notionHandler.executeWithRetry(any())).thenReturn(page);
+
+    var result = titleNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(1, result.getCreatedCount());
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/TitleReignNotionSyncServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/TitleReignNotionSyncServiceTest.java
@@ -1,0 +1,138 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.sync.entity.notion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.management.domain.title.Title;
+import com.github.javydreamercsw.management.domain.title.TitleReign;
+import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
+import com.github.javydreamercsw.management.service.sync.AbstractSyncTest;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import notion.api.v1.NotionClient;
+import notion.api.v1.model.pages.Page;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+class TitleReignNotionSyncServiceTest extends AbstractSyncTest {
+
+  private TitleReignNotionSyncService titleReignNotionSyncService;
+  @Captor private ArgumentCaptor<TitleReign> titleReignCaptor;
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+    titleReignNotionSyncService =
+        new TitleReignNotionSyncService(
+            titleReignRepository, syncServiceDependencies, notionApiExecutor);
+  }
+
+  @Test
+  @DisplayName("Sync new title reign creates Notion page and saves external ID")
+  void syncToNotion_newTitleReign_createsPageAndSavesExternalId() {
+    String operationId = UUID.randomUUID().toString();
+
+    Title title = new Title();
+    title.setName("World Championship");
+    title.setExternalId(UUID.randomUUID().toString());
+
+    Wrestler champion = new Wrestler();
+    champion.setName("The Champ");
+    champion.setExternalId(UUID.randomUUID().toString());
+
+    TitleReign reign = new TitleReign();
+    reign.setTitle(title);
+    reign.setStartDate(Instant.now());
+    reign.setReignNumber(1);
+    reign.getChampions().add(champion);
+
+    NotionClient client = mock(NotionClient.class);
+    when(titleReignRepository.findAll()).thenReturn(List.of(reign));
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_title_reigns");
+
+    Page page = mock(Page.class);
+    when(page.getId()).thenReturn(UUID.randomUUID().toString());
+    when(notionHandler.executeWithRetry(any())).thenReturn(page);
+
+    var result = titleReignNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(1, result.getCreatedCount());
+    assertEquals(0, result.getErrorCount());
+    verify(titleReignRepository, times(1)).saveAndFlush(titleReignCaptor.capture());
+    assertNotNull(titleReignCaptor.getValue().getExternalId());
+  }
+
+  @Test
+  @DisplayName("Sync with no title reigns returns zero counts")
+  void syncToNotion_empty_returnsZeroCounts() {
+    String operationId = UUID.randomUUID().toString();
+
+    NotionClient client = mock(NotionClient.class);
+    when(titleReignRepository.findAll()).thenReturn(Collections.emptyList());
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_title_reigns");
+
+    var result = titleReignNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(0, result.getCreatedCount());
+    assertEquals(0, result.getUpdatedCount());
+    assertEquals(0, result.getErrorCount());
+  }
+
+  @Test
+  @DisplayName("Title reign with notes and end date synced without error")
+  void syncToNotion_titleReignWithOptionalFields_syncedSuccessfully() {
+    String operationId = UUID.randomUUID().toString();
+
+    TitleReign reign = new TitleReign();
+    reign.setReignNumber(3);
+    reign.setStartDate(Instant.now().minusSeconds(86400));
+    reign.setEndDate(Instant.now());
+    reign.setNotes("Third reign was short but memorable");
+
+    NotionClient client = mock(NotionClient.class);
+    when(titleReignRepository.findAll()).thenReturn(List.of(reign));
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_title_reigns");
+
+    Page page = mock(Page.class);
+    when(page.getId()).thenReturn(UUID.randomUUID().toString());
+    when(notionHandler.executeWithRetry(any())).thenReturn(page);
+
+    var result = titleReignNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(1, result.getCreatedCount());
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/WrestlerNotionSyncServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/WrestlerNotionSyncServiceTest.java
@@ -1,0 +1,130 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.sync.entity.notion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.base.domain.wrestler.Gender;
+import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
+import com.github.javydreamercsw.management.service.sync.AbstractSyncTest;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import notion.api.v1.NotionClient;
+import notion.api.v1.model.pages.Page;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+class WrestlerNotionSyncServiceTest extends AbstractSyncTest {
+
+  private WrestlerNotionSyncService wrestlerNotionSyncService;
+  @Captor private ArgumentCaptor<Wrestler> wrestlerCaptor;
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+    wrestlerNotionSyncService =
+        new WrestlerNotionSyncService(
+            wrestlerRepository, syncServiceDependencies, notionApiExecutor);
+  }
+
+  @Test
+  @DisplayName("Sync new wrestler creates Notion page and saves external ID")
+  void syncToNotion_newWrestler_createsPageAndSavesExternalId() {
+    String operationId = UUID.randomUUID().toString();
+
+    Wrestler wrestler = new Wrestler();
+    wrestler.setName("Test Wrestler");
+    wrestler.setGender(Gender.MALE);
+    wrestler.setStartingHealth(100);
+    wrestler.setStartingStamina(100);
+
+    NotionClient client = mock(NotionClient.class);
+    when(wrestlerRepository.findAll()).thenReturn(List.of(wrestler));
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_wrestlers");
+
+    Page page = mock(Page.class);
+    when(page.getId()).thenReturn(UUID.randomUUID().toString());
+    when(notionHandler.executeWithRetry(any())).thenReturn(page);
+
+    var result = wrestlerNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(1, result.getCreatedCount());
+    assertEquals(0, result.getErrorCount());
+    verify(wrestlerRepository, times(1)).saveAndFlush(wrestlerCaptor.capture());
+    assertNotNull(wrestlerCaptor.getValue().getExternalId());
+  }
+
+  @Test
+  @DisplayName("Sync with no wrestlers returns zero counts")
+  void syncToNotion_empty_returnsZeroCounts() {
+    String operationId = UUID.randomUUID().toString();
+
+    NotionClient client = mock(NotionClient.class);
+    when(wrestlerRepository.findAll()).thenReturn(Collections.emptyList());
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_wrestlers");
+
+    var result = wrestlerNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(0, result.getCreatedCount());
+    assertEquals(0, result.getUpdatedCount());
+    assertEquals(0, result.getErrorCount());
+  }
+
+  @Test
+  @DisplayName("Wrestler with optional stats synced without error")
+  void syncToNotion_wrestlerWithOptionalStats_syncedSuccessfully() {
+    String operationId = UUID.randomUUID().toString();
+
+    Wrestler wrestler = new Wrestler();
+    wrestler.setName("Brawler");
+    wrestler.setGender(Gender.MALE);
+    wrestler.setBrawl(80);
+    wrestler.setCharisma(60);
+    wrestler.setDrive(70);
+    wrestler.setResilience(75);
+
+    NotionClient client = mock(NotionClient.class);
+    when(wrestlerRepository.findAll()).thenReturn(List.of(wrestler));
+    when(notionHandler.createNotionClient()).thenReturn(Optional.of(client));
+    when(notionHandler.getDatabaseId(anyString())).thenReturn("db_wrestlers");
+
+    Page page = mock(Page.class);
+    when(page.getId()).thenReturn(UUID.randomUUID().toString());
+    when(notionHandler.executeWithRetry(any())).thenReturn(page);
+
+    var result = wrestlerNotionSyncService.syncToNotion(operationId);
+
+    assertNotNull(result);
+    assertEquals(1, result.getCreatedCount());
+  }
+}


### PR DESCRIPTION
Add mocked unit tests for 6 *NotionSyncService classes that previously had no coverage:
- WrestlerNotionSyncService
- TitleNotionSyncService
- NpcNotionSyncService
- FactionNotionSyncService
- TeamNotionSyncService
- TitleReignNotionSyncService

Each test class covers: new entity creates page + saves externalId, empty repository returns zero counts, and entity with optional fields syncs without error. All extend AbstractSyncTest for shared mock setup.