### PR TITLE
fix(qr): use LAN IP in QR share URL when no HTTP request context is a…

### DIFF
--- a/src/main/java/com/github/javydreamercsw/management/util/UrlUtil.java
+++ b/src/main/java/com/github/javydreamercsw/management/util/UrlUtil.java
@@ -17,11 +17,16 @@
 package com.github.javydreamercsw.management.util;
 
 import com.vaadin.flow.server.VaadinServletRequest;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.Collections;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
 public final class UrlUtil {
 
   public static String getBaseUrl() {
@@ -39,6 +44,10 @@ public final class UrlUtil {
   /**
    * Like getBaseUrl() but replaces localhost/127.0.0.1 with the machine's LAN IP so QR codes are
    * scannable from phones on the same network.
+   *
+   * <p>When called outside a Vaadin HTTP request (e.g. from a WebSocket click listener),
+   * VaadinServletRequest.getCurrent() returns null. In that case we derive the URL from the
+   * machine's first non-loopback IPv4 address so the generated QR code still works on the LAN.
    */
   public static String getNetworkUrl() {
     String override = System.getenv("QR_BASE_URL");
@@ -54,7 +63,40 @@ public final class UrlUtil {
         String contextPath = request.getHttpServletRequest().getContextPath();
         return scheme + "://" + forwardedHost + contextPath;
       }
+      // We have a real HTTP request — use it, but swap localhost for the LAN IP
+      String base = getBaseUrl();
+      String lanIp = getLanIpAddress();
+      if (lanIp != null) {
+        base = base.replace("localhost", lanIp).replace("127.0.0.1", lanIp);
+      }
+      return base;
     }
-    return getBaseUrl();
+    // No HTTP request context (called from a WebSocket/push thread) — build from LAN IP directly
+    String lanIp = getLanIpAddress();
+    if (lanIp != null) {
+      return "http://" + lanIp + ":8080";
+    }
+    return "http://localhost:8080";
+  }
+
+  /** Returns the first non-loopback site-local IPv4 address, or null if none found. */
+  static String getLanIpAddress() {
+    try {
+      for (NetworkInterface iface : Collections.list(NetworkInterface.getNetworkInterfaces())) {
+        if (!iface.isUp() || iface.isLoopback() || iface.isVirtual()) {
+          continue;
+        }
+        for (InetAddress addr : Collections.list(iface.getInetAddresses())) {
+          if (!addr.isLoopbackAddress()
+              && addr.isSiteLocalAddress()
+              && addr.getAddress().length == 4) { // IPv4 only
+            return addr.getHostAddress();
+          }
+        }
+      }
+    } catch (Exception e) {
+      log.warn("Could not determine LAN IP address", e);
+    }
+    return null;
   }
 }

--- a/src/test/java/com/github/javydreamercsw/management/ui/view/show/ShowDetailQrCodeDocsE2ETest.java
+++ b/src/test/java/com/github/javydreamercsw/management/ui/view/show/ShowDetailQrCodeDocsE2ETest.java
@@ -1,0 +1,158 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.ui.view.show;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.javydreamercsw.AbstractE2ETest;
+import com.github.javydreamercsw.base.domain.account.Account;
+import com.github.javydreamercsw.base.domain.account.AccountRepository;
+import com.github.javydreamercsw.management.domain.show.Show;
+import com.github.javydreamercsw.management.domain.show.ShowRepository;
+import com.github.javydreamercsw.management.domain.show.segment.Segment;
+import com.github.javydreamercsw.management.domain.show.segment.SegmentRepository;
+import com.github.javydreamercsw.management.domain.show.segment.type.SegmentType;
+import com.github.javydreamercsw.management.domain.show.segment.type.SegmentTypeRepository;
+import com.github.javydreamercsw.management.domain.show.type.ShowType;
+import com.github.javydreamercsw.management.domain.show.type.ShowTypeRepository;
+import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
+import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Docs screenshot test: verifies that clicking the QR share button on a match segment opens a
+ * dialog displaying a QR code image with a LAN-accessible URL (not localhost).
+ */
+class ShowDetailQrCodeDocsE2ETest extends AbstractE2ETest {
+
+  @Autowired private ShowRepository showRepository;
+  @Autowired private ShowTypeRepository showTypeRepository;
+  @Autowired private WrestlerRepository wrestlerRepository;
+  @Autowired private AccountRepository accountRepository;
+  @Autowired private SegmentRepository segmentRepository;
+  @Autowired private SegmentTypeRepository segmentTypeRepository;
+
+  private Show testShow;
+  private Segment testSegment;
+
+  @BeforeEach
+  void setupQrTestData() {
+    ShowType showType =
+        showTypeRepository
+            .findByName("Weekly")
+            .orElseGet(
+                () -> {
+                  ShowType st = new ShowType();
+                  st.setName("Weekly");
+                  st.setExpectedMatches(3);
+                  st.setExpectedPromos(2);
+                  return showTypeRepository.save(st);
+                });
+
+    testShow = new Show();
+    testShow.setName("QR Code Test Show");
+    testShow.setShowDate(LocalDate.now());
+    testShow.setDescription("Show for QR code docs test");
+    testShow.setType(showType);
+    testShow.setUniverse(defaultUniverse);
+    testShow = showRepository.save(testShow);
+
+    Wrestler w1 = ensureWrestler("QR Test Alpha");
+    Wrestler w2 = ensureWrestler("QR Test Beta");
+
+    SegmentType matchType =
+        segmentTypeRepository
+            .findByName("One on One")
+            .orElseGet(segmentTypeRepository.findAll()::getFirst);
+
+    testSegment = new Segment();
+    testSegment.setShow(testShow);
+    testSegment.setSegmentType(matchType);
+    testSegment.addParticipant(w1);
+    testSegment.addParticipant(w2);
+    testSegment.setSegmentOrder(1);
+    testSegment = segmentRepository.saveAndFlush(testSegment);
+  }
+
+  @Test
+  void qrShareButtonOpensDialogWithQrCodeImage() {
+    driver.get("http://localhost:" + serverPort + getContextPath() + "/show/" + testShow.getId());
+    waitForVaadinClientToLoad();
+
+    // Click the QR share button for the test segment
+    WebElement qrButton =
+        waitForVaadinElement(driver, By.id("share-qr-button-" + testSegment.getId()));
+    clickElement(qrButton);
+    sleep(1500);
+
+    // Verify the dialog opened
+    WebElement dialog =
+        waitForVaadinElement(driver, By.cssSelector("vaadin-dialog-overlay[opened]"));
+    assertTrue(dialog.isDisplayed(), "QR dialog should be open");
+
+    // Verify the QR image is rendered
+    WebElement qrImage =
+        waitForVaadinElement(driver, By.cssSelector("img[alt='QR code for match']"));
+    assertTrue(qrImage.isDisplayed(), "QR code image should be visible");
+    String src = qrImage.getAttribute("src");
+    assertTrue(
+        src != null && src.startsWith("data:image/png;base64,"), "QR should be a base64 PNG");
+
+    // Verify the URL shown is not localhost (must be LAN-accessible)
+    WebElement urlLabel = dialog.findElement(By.cssSelector("vaadin-dialog-overlay span"));
+    String displayedUrl = urlLabel.getText();
+    assertFalse(
+        displayedUrl.contains("localhost") || displayedUrl.contains("127.0.0.1"),
+        "QR URL must use LAN IP, not localhost — got: " + displayedUrl);
+
+    documentFeature(
+        "Booker",
+        "QR Code Match Share",
+        "The QR share button on a match segment opens a dialog with a scannable QR code."
+            + " The URL uses the machine's LAN IP address so phones on the same network"
+            + " can navigate directly to the match page.",
+        "booker-show-detail-qr-code-share");
+  }
+
+  private Wrestler ensureWrestler(final String name) {
+    return wrestlerRepository
+        .findByName(name)
+        .orElseGet(
+            () -> {
+              Account account = new Account();
+              String uid = name.replaceAll("\\s+", "_") + "_" + System.currentTimeMillis();
+              account.setUsername(uid);
+              account.setEmail(uid + "@example.com");
+              account.setPassword("password");
+              account = accountRepository.save(account);
+              return wrestlerRepository.save(
+                  Wrestler.builder()
+                      .name(name)
+                      .startingHealth(100)
+                      .startingStamina(100)
+                      .account(account)
+                      .active(true)
+                      .build());
+            });
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/util/QrCodeUtilTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/util/QrCodeUtilTest.java
@@ -1,0 +1,43 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+class QrCodeUtilTest {
+
+  @Test
+  void toBase64PngProducesValidBase64() throws Exception {
+    String result = QrCodeUtil.toBase64Png("http://192.168.1.100:8080/atw-rpg/match/42", 256);
+    assertNotNull(result);
+    assertFalse(result.isBlank());
+    // verify it decodes without error
+    byte[] decoded = java.util.Base64.getDecoder().decode(result);
+    assertNotEquals(0, decoded.length);
+  }
+
+  @Test
+  void toBase64PngWorksWithLocalhostUrl() throws Exception {
+    String result = QrCodeUtil.toBase64Png("http://localhost:8080/match/1", 256);
+    assertNotNull(result);
+    assertFalse(result.isBlank());
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/util/UrlUtilTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/util/UrlUtilTest.java
@@ -1,0 +1,51 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+class UrlUtilTest {
+
+  @Test
+  void getLanIpAddressReturnsNonLocalhostAddress() {
+    String ip = UrlUtil.getLanIpAddress();
+    // May be null in CI with no network interfaces, but must not be a loopback if present
+    if (ip != null) {
+      assertNotEquals("127.0.0.1", ip);
+      assertNotEquals("::1", ip);
+      assertFalse(ip.isBlank());
+    }
+  }
+
+  @Test
+  void getNetworkUrlWithoutRequestContextDoesNotReturnLocalhostWhenLanAvailable() {
+    // No VaadinServletRequest is available in this unit test context
+    String url = UrlUtil.getNetworkUrl();
+    assertNotNull(url);
+    assertFalse(url.isBlank());
+    // If a LAN IP was found the URL must not say localhost
+    String lanIp = UrlUtil.getLanIpAddress();
+    if (lanIp != null) {
+      assertFalse(url.contains("localhost"), "Expected LAN IP in URL but got: " + url);
+      assertFalse(url.contains("127.0.0.1"), "Expected LAN IP in URL but got: " + url);
+    }
+  }
+}


### PR DESCRIPTION
### Problem

Clicking the QR share button on a match segment would always generate a code containing http://localhost:8080/match/{id}. That URL only resolves on the server itself — any phone or tablet on the same network scanning the code would get a connection error.

  Root cause: VaadinServletRequest.getCurrent() returns null when a click listener fires over a WebSocket/push connection rather than an HTTP request. The old fallback in UrlUtil.getNetworkUrl() was the hardcoded string "http://localhost:8080".

###  Fix

  UrlUtil.getNetworkUrl() now falls back to the machine's LAN IP when no HTTP request context is available. It enumerates NetworkInterface to find the first non-loopback site-local IPv4 address and uses that to build the URL. When a real HTTP request is present it also swaps localhost/127.0.0.1 for the LAN IP so the path is consistent.

  ### Priority order:
  1. QR_BASE_URL env var (reverse-proxy/production override — unchanged)
  2. X-Forwarded-Host header (unchanged)
  3. HTTP request URL with localhost replaced by LAN IP (new)
  4. LAN IP from NetworkInterface enumeration (new fallback for WebSocket context)
  5. http://localhost:8080 (last resort, no network interfaces found)

###   Tests

  - UrlUtilTest — unit tests for getLanIpAddress() and getNetworkUrl() asserting no localhost is returned when a LAN interface is available
  - QrCodeUtilTest — verifies toBase64Png() produces valid base64-encoded PNG output
  - ShowDetailQrCodeDocsE2ETest — docs E2E test that opens the show detail view, clicks the QR button, verifies the dialog renders a base64 PNG image, and asserts the embedded URL is not localhost

###   Test plan

  - Unit tests pass: mvn test -Dtest="QrCodeUtilTest,UrlUtilTest"
  - E2E docs test passes: mvn -Pgenerate-docs verify
  - Deploy WAR and click QR button on a match segment — dialog shows IP like 192.168.x.x, not localhost
  - Scan QR with phone on same LAN — navigates to correct match page