### PR TITLE
feat: granular CI path filters to skip E2E/integration tests on unrelated changes (ATW-8rj)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,6 +48,9 @@ jobs:
       code_changed: ${{ steps.filter.outputs.code_changed }}
       notion_changed: ${{ steps.filter.outputs.notion_changed }}
       mysql_migration_changed: ${{ steps.filter.outputs.mysql_migration_changed }}
+      ui_changed: ${{ steps.filter.outputs.ui_changed }}
+      service_changed: ${{ steps.filter.outputs.service_changed }}
+      db_changed: ${{ steps.filter.outputs.db_changed }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -68,6 +71,26 @@ jobs:
               - 'src/main/java/com/github/javydreamercsw/management/service/sync/**'
             mysql_migration_changed:
               - 'src/main/resources/db/migration/mysql/**'
+            # UI/frontend changes — gates E2E jobs (Chrome + Spring Boot startup are expensive)
+            ui_changed:
+              - 'src/main/java/**/ui/**'
+              - 'src/main/java/**/view/**'
+              - 'src/frontend/**'
+              - 'src/main/resources/META-INF/resources/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+              - 'vite.config.ts'
+            # Backend service/domain/API changes — gates integration tests
+            service_changed:
+              - 'src/main/java/**/service/**'
+              - 'src/main/java/**/repository/**'
+              - 'src/main/java/**/domain/**'
+              - 'src/main/java/**/rest/**'
+              - 'src/main/java/**/controller/**'
+            # DB migration changes — also gates integration tests
+            db_changed:
+              - 'src/main/resources/db/**'
 
   rewrite-check:
     needs: check-paths
@@ -113,7 +136,7 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     needs: [check-paths, build-and-unit-test]
-    if: needs.check-paths.outputs.code_changed == 'true'
+    if: needs.check-paths.outputs.service_changed == 'true' || needs.check-paths.outputs.db_changed == 'true'
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK 25
@@ -175,7 +198,7 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     needs: [check-paths, build-and-unit-test]
-    if: needs.check-paths.outputs.code_changed == 'true'
+    if: needs.check-paths.outputs.ui_changed == 'true'
     env:
       HEADLESS: 'true'
       GITHUB_ACTIONS: 'true'
@@ -209,7 +232,7 @@ jobs:
   docs-e2e-tests:
     runs-on: ubuntu-latest
     needs: [check-paths, build-and-unit-test]
-    if: needs.check-paths.outputs.code_changed == 'true'
+    if: needs.check-paths.outputs.ui_changed == 'true'
     env:
       HEADLESS: 'true'
       GITHUB_ACTIONS: 'true'
@@ -243,7 +266,7 @@ jobs:
   validate-video-tests:
     runs-on: ubuntu-latest
     needs: [check-paths, build-and-unit-test]
-    if: needs.check-paths.outputs.code_changed == 'true'
+    if: needs.check-paths.outputs.ui_changed == 'true'
     env:
       HEADLESS: 'true'
       GITHUB_ACTIONS: 'true'
@@ -306,7 +329,12 @@ jobs:
   coverage-and-analysis:
     runs-on: ubuntu-latest
     needs: [check-paths, build-and-unit-test, integration-tests, e2e-tests, docs-e2e-tests, validate-video-tests, notion-integration-tests, notion-e2e-tests]
-    if: always() && needs.check-paths.outputs.code_changed == 'true' && needs.build-and-unit-test.result == 'success' && needs.integration-tests.result == 'success' && needs.e2e-tests.result == 'success'
+    if: >-
+      always() &&
+      needs.check-paths.outputs.code_changed == 'true' &&
+      needs.build-and-unit-test.result == 'success' &&
+      (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped') &&
+      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK 25
@@ -418,7 +446,7 @@ jobs:
   docker-it:
     runs-on: ubuntu-latest
     needs: [check-paths, build-and-unit-test]
-    if: needs.check-paths.outputs.code_changed == 'true'
+    if: needs.check-paths.outputs.service_changed == 'true' || needs.check-paths.outputs.db_changed == 'true' || needs.check-paths.outputs.ui_changed == 'true'
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK 25

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -66,6 +66,7 @@ jobs:
               - 'tsconfig.json'
               - 'vite.config.ts'
               - 'scripts/sync-vaadin-overrides.cjs'
+              - '.github/workflows/**'
               - '!docs/**'
             notion_changed:
               - 'src/main/java/com/github/javydreamercsw/management/service/sync/**'
@@ -351,12 +352,14 @@ jobs:
         path: target/
 
     - name: Download integration test coverage data
+      if: needs.integration-tests.result == 'success'
       uses: actions/download-artifact@v8
       with:
         name: jacoco-it-exec
         path: target/
 
     - name: Download E2E test coverage data
+      if: needs.e2e-tests.result == 'success'
       uses: actions/download-artifact@v8
       with:
         name: jacoco-e2e-exec


### PR DESCRIPTION
## Summary
  
  - Adds `ui_changed`, `service_changed`, and `db_changed` path filter outputs to the `check-paths` job
  - Gates E2E jobs (`e2e-tests`, `docs-e2e-tests`, `validate-video-tests`) on `ui_changed` — they no longer fire on pure backend/service changes
  - Gates `integration-tests` and `docker-it` on `service_changed || db_changed` — they no longer fire on UI-only or doc changes
  - Updates `coverage-and-analysis` `if:` condition to accept `skipped` results for test jobs that were not triggered, so coverage merging still works on partial runs
  
  ## Motivation
  
  Every PR was running Chrome-backed E2E tests (frontend bundle build + Spring Boot startup + Selenium) even for backend-only changes like service logic, domain entities, or DB migrations. These jobs are the most expensive in the pipeline. No paid tooling required — this uses the `dorny/paths-filter` action that was already in place.
  
  ## Job gating after this change
  
  | Job | Before | After |
  |---|---|---|
  | `e2e-tests` | any `src/**` change | `ui_changed` only |
  | `docs-e2e-tests` | any `src/**` change | `ui_changed` only |
  | `validate-video-tests` | any `src/**` change | `ui_changed` only |
  | `integration-tests` | any `src/**` change | `service_changed` OR `db_changed` |
  | `docker-it` | any `src/**` change | `ui_changed` OR `service_changed` OR `db_changed` |
  | `build-and-unit-test` | any `src/**` change | unchanged |
  
  ## Test plan
  
  - [ ] Open a PR that only changes a service class — verify E2E jobs are skipped, integration tests run https://github.com/javydreamercsw/all-time-wrestling-rpg/pull/326
  - [ ] Open a PR that only changes a Vaadin view — verify E2E jobs run, integration tests are skipped https://github.com/javydreamercsw/all-time-wrestling-rpg/pull/328
  - [ ] Open a PR that changes a DB migration — verify integration tests run https://github.com/javydreamercsw/all-time-wrestling-rpg/pull/329
  - [ ] Open a PR that changes both UI and service code — verify all jobs run https://github.com/javydreamercsw/all-time-wrestling-rpg/pull/327
  - [ ] Verify `coverage-and-analysis` completes successfully when some test jobs were skipped