### PR TITLE
feat(alignment): spread wrestler alignment to universe/booker modes

### DIFF
--- a/src/main/java/com/github/javydreamercsw/management/DataInitializer.java
+++ b/src/main/java/com/github/javydreamercsw/management/DataInitializer.java
@@ -915,6 +915,7 @@ public class DataInitializer implements Initializable {
                       existingWrestler.setAlignment(
                           WrestlerAlignment.builder()
                               .wrestler(existingWrestler)
+                              .universe(universe)
                               .alignmentType(at)
                               .level(0)
                               .build());

--- a/src/main/java/com/github/javydreamercsw/management/domain/campaign/WrestlerAlignment.java
+++ b/src/main/java/com/github/javydreamercsw/management/domain/campaign/WrestlerAlignment.java
@@ -16,6 +16,7 @@
 */
 package com.github.javydreamercsw.management.domain.campaign;
 
+import com.github.javydreamercsw.management.domain.universe.Universe;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -52,6 +53,10 @@ public class WrestlerAlignment {
   @JoinColumn(name = "campaign_id")
   @com.fasterxml.jackson.annotation.JsonIgnore
   private Campaign campaign;
+
+  @ManyToOne
+  @JoinColumn(name = "universe_id")
+  private Universe universe;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "alignment_type", nullable = false)

--- a/src/main/java/com/github/javydreamercsw/management/domain/campaign/WrestlerAlignmentRepository.java
+++ b/src/main/java/com/github/javydreamercsw/management/domain/campaign/WrestlerAlignmentRepository.java
@@ -16,6 +16,7 @@
 */
 package com.github.javydreamercsw.management.domain.campaign;
 
+import com.github.javydreamercsw.management.domain.universe.Universe;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -27,10 +28,12 @@ import org.springframework.stereotype.Repository;
 public interface WrestlerAlignmentRepository extends JpaRepository<WrestlerAlignment, Long> {
   Optional<WrestlerAlignment> findByWrestler(Wrestler wrestler);
 
+  Optional<WrestlerAlignment> findByWrestlerAndUniverse(Wrestler wrestler, Universe universe);
+
   @Query(
       """
       SELECT wa FROM WrestlerAlignment wa WHERE wa.wrestler = :wrestler AND\
-       wa.campaign.universe.id = :universeId\
+       wa.universe.id = :universeId\
       """)
   Optional<WrestlerAlignment> findByWrestlerAndUniverseId(
       @Param("wrestler") Wrestler wrestler, @Param("universeId") Long universeId);

--- a/src/main/java/com/github/javydreamercsw/management/service/campaign/AlignmentService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/campaign/AlignmentService.java
@@ -23,6 +23,7 @@ import com.github.javydreamercsw.management.domain.campaign.CampaignState;
 import com.github.javydreamercsw.management.domain.campaign.CampaignStateRepository;
 import com.github.javydreamercsw.management.domain.campaign.WrestlerAlignment;
 import com.github.javydreamercsw.management.domain.campaign.WrestlerAlignmentRepository;
+import com.github.javydreamercsw.management.domain.universe.Universe;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import java.util.List;
 import java.util.Optional;
@@ -40,6 +41,34 @@ public class AlignmentService {
 
   private final WrestlerAlignmentRepository wrestlerAlignmentRepository;
   private final CampaignStateRepository campaignStateRepository;
+
+  public WrestlerAlignment getOrCreateUniverseAlignment(
+      @NonNull final Wrestler wrestler, @NonNull final Universe universe) {
+    return wrestlerAlignmentRepository
+        .findByWrestlerAndUniverse(wrestler, universe)
+        .orElseGet(
+            () -> {
+              WrestlerAlignment alignment =
+                  WrestlerAlignment.builder()
+                      .wrestler(wrestler)
+                      .universe(universe)
+                      .alignmentType(AlignmentType.NEUTRAL)
+                      .level(0)
+                      .build();
+              return wrestlerAlignmentRepository.save(alignment);
+            });
+  }
+
+  public WrestlerAlignment setUniverseAlignment(
+      @NonNull final Wrestler wrestler,
+      @NonNull final Universe universe,
+      @NonNull final AlignmentType type,
+      final int level) {
+    WrestlerAlignment alignment = getOrCreateUniverseAlignment(wrestler, universe);
+    alignment.setAlignmentType(type);
+    alignment.setLevel(Math.max(0, Math.min(5, level)));
+    return wrestlerAlignmentRepository.save(alignment);
+  }
 
   public void shiftAlignment(@NonNull final Campaign campaign, final int amount) {
     if (amount == 0) {

--- a/src/main/java/com/github/javydreamercsw/management/service/campaign/AlignmentService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/campaign/AlignmentService.java
@@ -141,7 +141,7 @@ public class AlignmentService {
       // Discard all cards of wrong alignment
       currentCards.clear();
       recalculatePendingPicks(state, alignment);
-      log.info(
+      log.debug(
           "Wrestler {} turned. Card inventory cleared and picks recalculated.", wrestler.getName());
     }
 
@@ -163,7 +163,7 @@ public class AlignmentService {
 
     // Grant first pick when reaching Level 1 from 0 (Neutral)
     if (oldLevel == 0 && newLevel >= 1 && type != AlignmentType.NEUTRAL) {
-      log.info("Reached Level 1 {}: Eligible for first Level 1 card.", type);
+      log.debug("Reached Level 1 {}: Eligible for first Level 1 card.", type);
       state.setPendingL1Picks(state.getPendingL1Picks() + 1);
     }
 
@@ -171,19 +171,19 @@ public class AlignmentService {
     if (type == AlignmentType.FACE) {
       // Face Level 4: Gain a level 2 card
       if (oldLevel < 4 && newLevel >= 4) {
-        log.info("Face reached Level 4: Eligible for Level 2 card.");
+        log.debug("Face reached Level 4: Eligible for Level 2 card.");
         state.setPendingL2Picks(state.getPendingL2Picks() + 1);
       }
       // Face Level 5: Gain a level 3 card, lose a level 1 card
       if (oldLevel < 5 && newLevel >= 5) {
-        log.info("Face reached Level 5: Gain Level 3 card, Lose Level 1 card.");
+        log.debug("Face reached Level 5: Gain Level 3 card, Lose Level 1 card.");
         removeOneCardOfLevel(cards, 1);
         state.setPendingL3Picks(state.getPendingL3Picks() + 1);
       }
     } else {
       // Heel Level 4: Gain a level 2 card, lose a level 1 card
       if (oldLevel < 4 && newLevel >= 4) {
-        log.info("Heel reached Level 4: Gain Level 2 card, Lose Level 1 card.");
+        log.debug("Heel reached Level 4: Gain Level 2 card, Lose Level 1 card.");
         removeOneCardOfLevel(cards, 1);
         state.setPendingL2Picks(state.getPendingL2Picks() + 1);
         if (state.getPendingL1Picks() > 0) {
@@ -192,7 +192,7 @@ public class AlignmentService {
       }
       // Heel Level 5: Gain another level 1 card
       if (oldLevel < 5 && newLevel >= 5) {
-        log.info("Heel reached Level 5: Eligible for another Level 1 card.");
+        log.debug("Heel reached Level 5: Eligible for another Level 1 card.");
         state.setPendingL1Picks(state.getPendingL1Picks() + 1);
       }
     }
@@ -208,7 +208,7 @@ public class AlignmentService {
         .ifPresent(
             card -> {
               cards.remove(card);
-              log.info("Removed Level {} card: {}", level, card.getName());
+              log.debug("Removed Level {} card: {}", level, card.getName());
             });
   }
 

--- a/src/main/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationService.java
@@ -33,6 +33,7 @@ import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.event.ChampionshipChangeEvent;
 import com.github.javydreamercsw.management.event.ChampionshipDefendedEvent;
 import com.github.javydreamercsw.management.service.GameSettingService;
+import com.github.javydreamercsw.management.service.campaign.AlignmentService;
 import com.github.javydreamercsw.management.service.campaign.WrestlerStatusService;
 import com.github.javydreamercsw.management.service.faction.FactionService;
 import com.github.javydreamercsw.management.service.feud.FeudResolutionService;
@@ -96,6 +97,10 @@ public class SegmentAdjudicationService {
   // Null-safe: when null (unit tests), reattach() is a no-op.
   @Setter(onMethod_ = {@Autowired})
   private SegmentRepository segmentRepository;
+
+  // Field-injected for the same reason — null-safe, falls back to wrestler.getAlignment().
+  @Setter(onMethod_ = {@Autowired})
+  private AlignmentService alignmentService;
 
   @Autowired
   public SegmentAdjudicationService(
@@ -603,30 +608,38 @@ public class SegmentAdjudicationService {
     }
   }
 
+  private com.github.javydreamercsw.management.domain.campaign.WrestlerAlignment resolveAlignment(
+      final Wrestler wrestler, final Segment segment) {
+    if (alignmentService != null && segment.getShow().getUniverse() != null) {
+      return alignmentService.getOrCreateUniverseAlignment(
+          wrestler, segment.getShow().getUniverse());
+    }
+    return wrestler.getAlignment();
+  }
+
   private long applyVenueBonuses(
       final Segment segment, final Wrestler wrestler, final long amount) {
     double modifier = 1.0;
 
     // Arena Alignment Bias (+25%)
-    if (segment.getShow().getArena() != null
-        && wrestler.getAlignment() != null
-        && wrestler.getAlignment().getAlignmentType() != null) {
+    if (segment.getShow().getArena() != null) {
+      com.github.javydreamercsw.management.domain.campaign.WrestlerAlignment effectiveAlignment =
+          resolveAlignment(wrestler, segment);
       com.github.javydreamercsw.management.domain.world.Arena arena = segment.getShow().getArena();
-      String wrestlerAlignment = wrestler.getAlignment().getAlignmentType().name();
-
-      boolean matches = false;
-      switch (arena.getAlignmentBias()) {
-        case FACE_FAVORABLE -> matches = "FACE".equals(wrestlerAlignment);
-        case HEEL_FAVORABLE -> matches = "HEEL".equals(wrestlerAlignment);
-        case ANARCHIC -> matches = true; // Everyone gets a boost in anarchy
-        case NEUTRAL -> matches = false;
-      }
-
-      if (matches) {
-        modifier += 0.25;
-        log.debug(
-            "Applying 25% Arena Bias bonus to {}. Arena: {}, Bias: {}",
-            wrestler.getName(), arena.getName(), arena.getAlignmentBias());
+      if (effectiveAlignment != null && effectiveAlignment.getAlignmentType() != null) {
+        String wrestlerAlignment = effectiveAlignment.getAlignmentType().name();
+        boolean matches = false;
+        switch (arena.getAlignmentBias()) {
+          case FACE_FAVORABLE -> matches = "FACE".equals(wrestlerAlignment);
+          case HEEL_FAVORABLE -> matches = "HEEL".equals(wrestlerAlignment);
+          case ANARCHIC -> matches = true; // Everyone gets a boost in anarchy
+        }
+        if (matches) {
+          modifier += 0.25;
+          log.debug(
+              "Applying 25% Arena Bias bonus to {}. Arena: {}, Bias: {}",
+              wrestler.getName(), arena.getName(), arena.getAlignmentBias());
+        }
       }
     }
 

--- a/src/main/java/com/github/javydreamercsw/management/ui/component/AlignmentTrackComponent.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/component/AlignmentTrackComponent.java
@@ -27,6 +27,10 @@ import com.vaadin.flow.theme.lumo.LumoUtility;
 public class AlignmentTrackComponent extends Div {
 
   public AlignmentTrackComponent(final WrestlerAlignment alignment) {
+    this(alignment, true);
+  }
+
+  public AlignmentTrackComponent(final WrestlerAlignment alignment, final boolean showMilestones) {
     addClassNames(
         LumoUtility.Display.FLEX,
         LumoUtility.FlexDirection.COLUMN,
@@ -40,8 +44,7 @@ public class AlignmentTrackComponent extends Div {
     int currentLevel = alignment.getLevel();
 
     Span title =
-        new Span(
-            "Campaign Alignment: " + (type == AlignmentType.NEUTRAL ? "NEUTRAL" : type.name()));
+        new Span("Alignment: " + (type == AlignmentType.NEUTRAL ? "NEUTRAL" : type.name()));
     title.addClassNames(LumoUtility.FontWeight.BOLD, LumoUtility.TextColor.PRIMARY);
     add(title);
 
@@ -83,26 +86,28 @@ public class AlignmentTrackComponent extends Div {
 
     add(trackContainer);
 
-    // Legend / Milestone Description (Side-by-Side)
-    Div legendContainer = new Div();
-    legendContainer.addClassNames(
-        LumoUtility.Display.FLEX, LumoUtility.JustifyContent.BETWEEN, LumoUtility.Gap.MEDIUM);
-    legendContainer.getStyle().set("flex-wrap", "nowrap");
+    if (showMilestones) {
+      // Legend / Milestone Description (Side-by-Side)
+      Div legendContainer = new Div();
+      legendContainer.addClassNames(
+          LumoUtility.Display.FLEX, LumoUtility.JustifyContent.BETWEEN, LumoUtility.Gap.MEDIUM);
+      legendContainer.getStyle().set("flex-wrap", "nowrap");
 
-    Div heelLegend = new Div();
-    heelHelegendStyle(heelLegend);
-    addMilestoneText(heelLegend, "1", "Unlock first Level 1 Heel Card.");
-    addMilestoneText(heelLegend, "4", "Unlock Level 2 Card. (Lose 1 L1 card)");
-    addMilestoneText(heelLegend, "5", "Regain slot with another Level 1 Card.");
+      Div heelLegend = new Div();
+      heelHelegendStyle(heelLegend);
+      addMilestoneText(heelLegend, "1", "Unlock first Level 1 Heel Card.");
+      addMilestoneText(heelLegend, "4", "Unlock Level 2 Card. (Lose 1 L1 card)");
+      addMilestoneText(heelLegend, "5", "Regain slot with another Level 1 Card.");
 
-    Div faceLegend = new Div();
-    faceLegendStyle(faceLegend);
-    addMilestoneText(faceLegend, "1", "Unlock first Level 1 Face Card.");
-    addMilestoneText(faceLegend, "4", "Unlock powerful Level 2 Card.");
-    addMilestoneText(faceLegend, "5", "Unlock Level 3 Finisher! (Lose 1 L1 card)");
+      Div faceLegend = new Div();
+      faceLegendStyle(faceLegend);
+      addMilestoneText(faceLegend, "1", "Unlock first Level 1 Face Card.");
+      addMilestoneText(faceLegend, "4", "Unlock powerful Level 2 Card.");
+      addMilestoneText(faceLegend, "5", "Unlock Level 3 Finisher! (Lose 1 L1 card)");
 
-    legendContainer.add(heelLegend, faceLegend);
-    add(legendContainer);
+      legendContainer.add(heelLegend, faceLegend);
+      add(legendContainer);
+    }
   }
 
   private void heelHelegendStyle(final Div div) {

--- a/src/main/java/com/github/javydreamercsw/management/ui/component/WrestlerActionMenu.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/component/WrestlerActionMenu.java
@@ -22,6 +22,7 @@ import com.github.javydreamercsw.base.service.account.AccountService;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerStateRepository;
+import com.github.javydreamercsw.management.service.campaign.AlignmentService;
 import com.github.javydreamercsw.management.service.campaign.CampaignService;
 import com.github.javydreamercsw.management.service.injury.InjuryService;
 import com.github.javydreamercsw.management.service.npc.NpcService;
@@ -67,7 +68,8 @@ public class WrestlerActionMenu extends MenuBar {
       @NonNull final SecurityUtils securityUtils,
       @NonNull @Qualifier("baseAccountService") final AccountService accountService,
       @NonNull final ImageStorageService imageStorageService,
-      @NonNull final UniverseContextService universeContextService) {
+      @NonNull final UniverseContextService universeContextService,
+      @NonNull final AlignmentService alignmentService) {
     this.accountService = accountService;
 
     Long universeId = universeContextService.getCurrentUniverseId();
@@ -115,7 +117,8 @@ public class WrestlerActionMenu extends MenuBar {
                       wrestler,
                       refreshProvider,
                       securityUtils,
-                      universeContextService);
+                      universeContextService,
+                      alignmentService);
               dialog.open();
             });
     editItem.addComponentAsFirst(new Icon(VaadinIcon.EDIT));

--- a/src/main/java/com/github/javydreamercsw/management/ui/view/wrestler/WrestlerDialog.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/view/wrestler/WrestlerDialog.java
@@ -202,7 +202,7 @@ public class WrestlerDialog extends Dialog {
 
     if (canEditAlignment) {
       Universe currentUniverse = universeContextService.getCurrentUniverse().orElse(null);
-      if (currentUniverse != null) {
+      if (currentUniverse != null && this.wrestler.getId() != null) {
         WrestlerAlignment existing =
             alignmentService.getOrCreateUniverseAlignment(this.wrestler, currentUniverse);
         alignmentTypeField.setValue(existing.getAlignmentType());

--- a/src/main/java/com/github/javydreamercsw/management/ui/view/wrestler/WrestlerDialog.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/view/wrestler/WrestlerDialog.java
@@ -22,10 +22,14 @@ import com.github.javydreamercsw.base.domain.wrestler.Gender;
 import com.github.javydreamercsw.base.security.SecurityUtils;
 import com.github.javydreamercsw.base.service.account.AccountService;
 import com.github.javydreamercsw.base.ui.component.ImageUploadComponent;
+import com.github.javydreamercsw.management.domain.campaign.AlignmentType;
+import com.github.javydreamercsw.management.domain.campaign.WrestlerAlignment;
 import com.github.javydreamercsw.management.domain.npc.Npc;
+import com.github.javydreamercsw.management.domain.universe.Universe;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerStateRepository;
+import com.github.javydreamercsw.management.service.campaign.AlignmentService;
 import com.github.javydreamercsw.management.service.npc.NpcService;
 import com.github.javydreamercsw.management.service.universe.UniverseContextService;
 import com.github.javydreamercsw.management.service.wrestler.WrestlerService;
@@ -51,6 +55,7 @@ public class WrestlerDialog extends Dialog {
   private final NpcService npcService;
   private final ImageStorageService imageStorageService;
   private final UniverseContextService universeContextService;
+  private final AlignmentService alignmentService;
   private final Wrestler wrestler;
   private final Binder<Wrestler> binder = new Binder<>(Wrestler.class);
   private final SecurityUtils securityUtils;
@@ -63,7 +68,8 @@ public class WrestlerDialog extends Dialog {
       @NonNull final WrestlerStateRepository wrestlerStateRepository,
       @NonNull final Runnable onSave,
       @NonNull final SecurityUtils securityUtils,
-      @NonNull final UniverseContextService universeContextService) {
+      @NonNull final UniverseContextService universeContextService,
+      @NonNull final AlignmentService alignmentService) {
     this(
         wrestlerService,
         accountService,
@@ -73,7 +79,8 @@ public class WrestlerDialog extends Dialog {
         createDefaultWrestler(),
         onSave,
         securityUtils,
-        universeContextService);
+        universeContextService,
+        alignmentService);
     setHeaderTitle("Create Wrestler");
   }
 
@@ -101,13 +108,15 @@ public class WrestlerDialog extends Dialog {
       @NonNull final Wrestler wrestler,
       @NonNull final Runnable onSave,
       @NonNull final SecurityUtils securityUtils,
-      @NonNull final UniverseContextService universeContextService) {
+      @NonNull final UniverseContextService universeContextService,
+      @NonNull final AlignmentService alignmentService) {
     this.wrestlerService = wrestlerService;
     this.accountService = accountService;
     this.npcService = npcService;
     this.imageStorageService = imageStorageService;
     this.wrestlerStateRepository = wrestlerStateRepository;
     this.universeContextService = universeContextService;
+    this.alignmentService = alignmentService;
     this.wrestler = wrestler;
     this.securityUtils = securityUtils;
 
@@ -176,6 +185,34 @@ public class WrestlerDialog extends Dialog {
         com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment.BASELINE);
     imageEditLayout.setWidthFull();
 
+    boolean canEditAlignment = securityUtils.isAdmin() || securityUtils.isBooker();
+    ComboBox<AlignmentType> alignmentTypeField = new ComboBox<>("Alignment");
+    alignmentTypeField.setItems(AlignmentType.values());
+    alignmentTypeField.setId("wrestler-dialog-alignment-type-field");
+    alignmentTypeField.setVisible(canEditAlignment);
+    alignmentTypeField.setValue(AlignmentType.NEUTRAL);
+
+    IntegerField alignmentLevelField = new IntegerField("Alignment Level (0-5)");
+    alignmentLevelField.setMin(0);
+    alignmentLevelField.setMax(5);
+    alignmentLevelField.setId("wrestler-dialog-alignment-level-field");
+    alignmentLevelField.setVisible(canEditAlignment);
+    alignmentLevelField.setValue(0);
+    alignmentLevelField.setEnabled(false);
+
+    if (canEditAlignment) {
+      Universe currentUniverse = universeContextService.getCurrentUniverse().orElse(null);
+      if (currentUniverse != null) {
+        WrestlerAlignment existing =
+            alignmentService.getOrCreateUniverseAlignment(this.wrestler, currentUniverse);
+        alignmentTypeField.setValue(existing.getAlignmentType());
+        alignmentLevelField.setValue(existing.getLevel());
+        alignmentLevelField.setEnabled(existing.getAlignmentType() != AlignmentType.NEUTRAL);
+      }
+      alignmentTypeField.addValueChangeListener(
+          e -> alignmentLevelField.setEnabled(e.getValue() != AlignmentType.NEUTRAL));
+    }
+
     Checkbox isPlayerField = new Checkbox("Is Player");
     isPlayerField.setId("wrestler-dialog-is-player-field");
     isPlayerField.setReadOnly(!securityUtils.isAdmin() && !securityUtils.isBooker());
@@ -217,6 +254,8 @@ public class WrestlerDialog extends Dialog {
         lowStaminaField,
         descriptionField,
         imageEditLayout,
+        alignmentTypeField,
+        alignmentLevelField,
         isPlayerField,
         activeField,
         accountComboBox);
@@ -261,6 +300,21 @@ public class WrestlerDialog extends Dialog {
                             state.setManager(managerField.getValue());
                             wrestlerStateRepository.save(state);
                           });
+
+                  // Save universe-level alignment (Booker/Admin only)
+                  if (canEditAlignment && alignmentTypeField.getValue() != null) {
+                    universeContextService
+                        .getCurrentUniverse()
+                        .ifPresent(
+                            u ->
+                                alignmentService.setUniverseAlignment(
+                                    savedWrestler,
+                                    u,
+                                    alignmentTypeField.getValue(),
+                                    alignmentLevelField.getValue() != null
+                                        ? alignmentLevelField.getValue()
+                                        : 0));
+                  }
 
                   // Handle account assignment if isPlayer is true and an account is selected
                   if (isPlayerField.getValue()) {

--- a/src/main/java/com/github/javydreamercsw/management/ui/view/wrestler/WrestlerListView.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/view/wrestler/WrestlerListView.java
@@ -20,9 +20,12 @@ import com.github.javydreamercsw.base.ai.image.ImageStorageService;
 import com.github.javydreamercsw.base.security.SecurityUtils;
 import com.github.javydreamercsw.base.service.account.AccountService;
 import com.github.javydreamercsw.base.ui.component.ViewToolbar;
+import com.github.javydreamercsw.management.domain.campaign.AlignmentType;
+import com.github.javydreamercsw.management.domain.campaign.WrestlerAlignment;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerStateRepository;
+import com.github.javydreamercsw.management.service.campaign.AlignmentService;
 import com.github.javydreamercsw.management.service.campaign.CampaignService;
 import com.github.javydreamercsw.management.service.expansion.ExpansionService;
 import com.github.javydreamercsw.management.service.injury.InjuryService;
@@ -69,6 +72,7 @@ public class WrestlerListView extends Main {
   private final ImageStorageService imageStorageService;
   private final UniverseContextService universeContextService;
   private final WrestlerStateRepository wrestlerStateRepository;
+  private final AlignmentService alignmentService;
   private Set<Long> injuredWrestlerIds;
   final Grid<Wrestler> wrestlerGrid;
 
@@ -83,7 +87,8 @@ public class WrestlerListView extends Main {
       @NonNull final CampaignService campaignService,
       @NonNull final ImageStorageService imageStorageService,
       @NonNull final UniverseContextService universeContextService,
-      @NonNull final WrestlerStateRepository wrestlerStateRepository) {
+      @NonNull final WrestlerStateRepository wrestlerStateRepository,
+      @NonNull final AlignmentService alignmentService) {
     this.wrestlerService = wrestlerService;
     this.injuryService = injuryService;
     this.npcService = npcService;
@@ -94,6 +99,7 @@ public class WrestlerListView extends Main {
     this.imageStorageService = imageStorageService;
     this.universeContextService = universeContextService;
     this.wrestlerStateRepository = wrestlerStateRepository;
+    this.alignmentService = alignmentService;
     wrestlerGrid = new Grid<>();
     reloadGrid();
 
@@ -127,6 +133,29 @@ public class WrestlerListView extends Main {
                     nameLayout.add(userIcon);
                   }
                   nameLayout.add(new Span(wrestler.getName()));
+                  universeContextService
+                      .getCurrentUniverse()
+                      .ifPresent(
+                          universe -> {
+                            WrestlerAlignment alignment =
+                                alignmentService.getOrCreateUniverseAlignment(wrestler, universe);
+                            Span badge = new Span(alignment.getAlignmentType().name());
+                            badge.getStyle().set("font-size", "var(--lumo-font-size-xs)");
+                            badge.getStyle().set("padding", "0 4px");
+                            badge.getStyle().set("border-radius", "4px");
+                            badge.getStyle().set("font-weight", "bold");
+                            if (alignment.getAlignmentType() == AlignmentType.FACE) {
+                              badge.getStyle().set("background-color", "#c8e6c9");
+                              badge.getStyle().set("color", "#1b5e20");
+                            } else if (alignment.getAlignmentType() == AlignmentType.HEEL) {
+                              badge.getStyle().set("background-color", "#ffcdd2");
+                              badge.getStyle().set("color", "#b71c1c");
+                            } else {
+                              badge.getStyle().set("background-color", "#e0e0e0");
+                              badge.getStyle().set("color", "#424242");
+                            }
+                            nameLayout.add(badge);
+                          });
                   return nameLayout;
                 })
             .setHeader("Name")
@@ -211,7 +240,8 @@ public class WrestlerListView extends Main {
                       securityUtils,
                       accountService,
                       imageStorageService,
-                      universeContextService);
+                      universeContextService,
+                      alignmentService);
               wrestlerActionMenu.setId("action-menu-" + wrestler.getId());
               return wrestlerActionMenu;
             })
@@ -252,7 +282,8 @@ public class WrestlerListView extends Main {
                       wrestlerStateRepository,
                       this::reloadGrid,
                       securityUtils,
-                      universeContextService);
+                      universeContextService,
+                      alignmentService);
               dialog.open();
             });
     button.addThemeVariants(ButtonVariant.LUMO_PRIMARY);

--- a/src/main/java/com/github/javydreamercsw/management/ui/view/wrestler/WrestlerProfileView.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/view/wrestler/WrestlerProfileView.java
@@ -34,6 +34,7 @@ import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerStateRepository;
 import com.github.javydreamercsw.management.dto.ranking.TitleReignDTO;
+import com.github.javydreamercsw.management.service.campaign.AlignmentService;
 import com.github.javydreamercsw.management.service.campaign.CampaignService;
 import com.github.javydreamercsw.management.service.feud.MultiWrestlerFeudService;
 import com.github.javydreamercsw.management.service.injury.InjuryService;
@@ -45,6 +46,7 @@ import com.github.javydreamercsw.management.service.segment.SegmentService;
 import com.github.javydreamercsw.management.service.title.TitleService;
 import com.github.javydreamercsw.management.service.universe.UniverseContextService;
 import com.github.javydreamercsw.management.service.wrestler.WrestlerService;
+import com.github.javydreamercsw.management.ui.component.AlignmentTrackComponent;
 import com.github.javydreamercsw.management.ui.component.HistoryTimelineComponent;
 import com.github.javydreamercsw.management.ui.component.ReignCardComponent;
 import com.github.javydreamercsw.management.ui.component.WrestlerActionMenu;
@@ -117,6 +119,7 @@ public class WrestlerProfileView extends Main implements BeforeEnterObserver {
   private final com.github.javydreamercsw.management.service.campaign.StatusCardService
       statusCardService;
   private final WrestlerStateRepository wrestlerStateRepository;
+  private final AlignmentService alignmentService;
 
   private Wrestler wrestler;
   private Season selectedSeason; // To store the selected season for filtering
@@ -163,7 +166,8 @@ public class WrestlerProfileView extends Main implements BeforeEnterObserver {
           wrestlerStatusService,
       final com.github.javydreamercsw.management.service.campaign.StatusCardService
           statusCardService,
-      final WrestlerStateRepository wrestlerStateRepository) {
+      final WrestlerStateRepository wrestlerStateRepository,
+      final AlignmentService alignmentService) {
     this.wrestlerService = wrestlerService;
     this.wrestlerRepository = wrestlerRepository;
     this.titleService = titleService;
@@ -182,6 +186,7 @@ public class WrestlerProfileView extends Main implements BeforeEnterObserver {
     this.wrestlerStatusService = wrestlerStatusService;
     this.statusCardService = statusCardService;
     this.wrestlerStateRepository = wrestlerStateRepository;
+    this.alignmentService = alignmentService;
     wrestlerName.setId("wrestler-name");
     wrestlerImage.setAlt("Wrestler Image");
     wrestlerImage.setId("wrestler-image");
@@ -338,7 +343,8 @@ public class WrestlerProfileView extends Main implements BeforeEnterObserver {
               securityUtils,
               accountService,
               imageStorageService,
-              universeContextService));
+              universeContextService,
+              alignmentService));
       wrestlerName.setText(wrestler.getName());
       String details = "Gender: %s, Fans: %d".formatted(wrestler.getGender(), state.getFans());
       if (wrestler.getHeritageTag() != null && !wrestler.getHeritageTag().isEmpty()) {
@@ -379,6 +385,15 @@ public class WrestlerProfileView extends Main implements BeforeEnterObserver {
       } else {
         statsLayout.add(new Paragraph("Stats not available."));
       }
+
+      universeContextService
+          .getCurrentUniverse()
+          .ifPresent(
+              universe -> {
+                com.github.javydreamercsw.management.domain.campaign.WrestlerAlignment alignment =
+                    alignmentService.getOrCreateUniverseAlignment(wrestler, universe);
+                statsLayout.add(new AlignmentTrackComponent(alignment, false));
+              });
 
       // Status Cards
       statusesLayout.removeAll();

--- a/src/main/resources/db/migration/h2/V84__Add_Universe_Alignment.sql
+++ b/src/main/resources/db/migration/h2/V84__Add_Universe_Alignment.sql
@@ -1,0 +1,4 @@
+ALTER TABLE wrestler_alignment ADD COLUMN universe_id BIGINT NULL;
+ALTER TABLE wrestler_alignment ADD CONSTRAINT fk_wrestler_alignment_universe
+    FOREIGN KEY (universe_id) REFERENCES universe(id);
+CREATE INDEX idx_wrestler_alignment_universe ON wrestler_alignment(wrestler_id, universe_id);

--- a/src/main/resources/db/migration/mysql/V54__Add_Universe_Alignment.sql
+++ b/src/main/resources/db/migration/mysql/V54__Add_Universe_Alignment.sql
@@ -1,0 +1,4 @@
+ALTER TABLE wrestler_alignment ADD COLUMN universe_id BIGINT NULL;
+ALTER TABLE wrestler_alignment ADD CONSTRAINT fk_wrestler_alignment_universe
+    FOREIGN KEY (universe_id) REFERENCES universe(id);
+CREATE INDEX idx_wrestler_alignment_universe ON wrestler_alignment(wrestler_id, universe_id);

--- a/src/test/java/com/github/javydreamercsw/management/service/campaign/AlignmentServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/campaign/AlignmentServiceTest.java
@@ -17,6 +17,8 @@
 package com.github.javydreamercsw.management.service.campaign;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -31,6 +33,7 @@ import com.github.javydreamercsw.management.domain.campaign.CampaignState;
 import com.github.javydreamercsw.management.domain.campaign.CampaignStateRepository;
 import com.github.javydreamercsw.management.domain.campaign.WrestlerAlignment;
 import com.github.javydreamercsw.management.domain.campaign.WrestlerAlignmentRepository;
+import com.github.javydreamercsw.management.domain.universe.Universe;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import java.util.ArrayList;
 import java.util.List;
@@ -614,5 +617,79 @@ class AlignmentServiceTest {
     // Only handleLevelChange saves, not updateAbilityCards
     verify(campaignStateRepository, times(1)).save(state);
     assertEquals(originalSize, state.getActiveCards().size());
+  }
+
+  // ==================== getOrCreateUniverseAlignment ====================
+
+  @Test
+  void getOrCreateUniverseAlignment_createsNeutralWhenNotFound() {
+    Universe universe = Universe.builder().name("Test Universe").build();
+    when(wrestlerAlignmentRepository.findByWrestlerAndUniverse(wrestler, universe))
+        .thenReturn(Optional.empty());
+
+    WrestlerAlignment result = alignmentService.getOrCreateUniverseAlignment(wrestler, universe);
+
+    assertNotNull(result);
+    assertEquals(AlignmentType.NEUTRAL, result.getAlignmentType());
+    assertEquals(0, result.getLevel());
+    verify(wrestlerAlignmentRepository).save(any(WrestlerAlignment.class));
+  }
+
+  @Test
+  void getOrCreateUniverseAlignment_returnsExistingRecord() {
+    Universe universe = Universe.builder().name("Test Universe").build();
+    WrestlerAlignment existing =
+        WrestlerAlignment.builder()
+            .wrestler(wrestler)
+            .universe(universe)
+            .alignmentType(AlignmentType.FACE)
+            .level(3)
+            .build();
+    when(wrestlerAlignmentRepository.findByWrestlerAndUniverse(wrestler, universe))
+        .thenReturn(Optional.of(existing));
+
+    WrestlerAlignment result = alignmentService.getOrCreateUniverseAlignment(wrestler, universe);
+
+    assertSame(existing, result);
+    verify(wrestlerAlignmentRepository, never()).save(any());
+  }
+
+  // ==================== setUniverseAlignment ====================
+
+  @Test
+  void setUniverseAlignment_persistsTypeAndLevel() {
+    Universe universe = Universe.builder().name("Test Universe").build();
+    when(wrestlerAlignmentRepository.findByWrestlerAndUniverse(wrestler, universe))
+        .thenReturn(Optional.empty());
+
+    WrestlerAlignment result =
+        alignmentService.setUniverseAlignment(wrestler, universe, AlignmentType.HEEL, 4);
+
+    assertEquals(AlignmentType.HEEL, result.getAlignmentType());
+    assertEquals(4, result.getLevel());
+  }
+
+  @Test
+  void setUniverseAlignment_clampsLevelToMaxFive() {
+    Universe universe = Universe.builder().name("Test Universe").build();
+    when(wrestlerAlignmentRepository.findByWrestlerAndUniverse(wrestler, universe))
+        .thenReturn(Optional.empty());
+
+    WrestlerAlignment result =
+        alignmentService.setUniverseAlignment(wrestler, universe, AlignmentType.FACE, 99);
+
+    assertEquals(5, result.getLevel());
+  }
+
+  @Test
+  void setUniverseAlignment_clampsLevelToMinZero() {
+    Universe universe = Universe.builder().name("Test Universe").build();
+    when(wrestlerAlignmentRepository.findByWrestlerAndUniverse(wrestler, universe))
+        .thenReturn(Optional.empty());
+
+    WrestlerAlignment result =
+        alignmentService.setUniverseAlignment(wrestler, universe, AlignmentType.HEEL, -3);
+
+    assertEquals(0, result.getLevel());
   }
 }

--- a/src/test/java/com/github/javydreamercsw/management/ui/view/wrestler/WrestlerListViewE2ETest.java
+++ b/src/test/java/com/github/javydreamercsw/management/ui/view/wrestler/WrestlerListViewE2ETest.java
@@ -146,11 +146,13 @@ class WrestlerListViewE2ETest extends AbstractE2ETest {
 
     // Get all cell contents
     List<WebElement> cells = driver.findElements(By.tagName("vaadin-grid-cell-content"));
+    List<String> targets = List.of("Adam", "Ben", "Zack");
     List<String> namesInOrder =
         cells.stream()
             .map(WebElement::getText)
             .map(String::trim)
-            .filter(text -> "Adam".equals(text) || "Ben".equals(text) || "Zack".equals(text))
+            .map(text -> text.split("\\s+")[0])
+            .filter(targets::contains)
             .toList();
 
     assertEquals(3, namesInOrder.size(), "Should find all three wrestler names in the grid");


### PR DESCRIPTION

- Add universe_id FK to wrestler_alignment table (V84/V54 migrations)
- Add Universe field to WrestlerAlignment entity and repository finder
- Add getOrCreateUniverseAlignment and setUniverseAlignment to AlignmentService
- SegmentAdjudicationService resolves alignment from universe context for arena bias
- DataInitializer attaches default universe when importing wrestler alignment
- WrestlerDialog exposes alignment editor for Booker/Admin roles
- WrestlerListView shows FACE/HEEL/NEUTRAL badge next to wrestler name
- WrestlerProfileView renders AlignmentTrackComponent in Stats section
- AlignmentTrackComponent: fix hardcoded "Campaign Alignment" label; add showMilestones param
- AlignmentServiceTest: 5 new tests for universe-scoped alignment methods