### PR TITLE
fix(notion-tests): guard live tests and add cleanup extension (#331)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,11 @@
 {
+  "permissions": {
+    "allow": [
+      "mcp__github__pull_request_read",
+      "mcp__github__get_file_contents",
+      "mcp__github__issue_read"
+    ]
+  },
   "hooks": {
     "PreCompact": [
       {

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -187,7 +187,7 @@ jobs:
         cache: maven
 
     - name: Run Notion Integration Tests
-      run: mvn -B verify -Pnotion-it,coverage -Dsurefire.skip=true
+      run: mvn -B verify -Pnotion-it,coverage -Dsurefire.skip=true -Dnotion.live.tests.enabled=true
 
     - name: Upload notion integration test coverage data
       uses: actions/upload-artifact@v7

--- a/src/test/java/com/github/javydreamercsw/management/annotation/NotionLiveTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/annotation/NotionLiveTest.java
@@ -1,0 +1,44 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Marks a test or class as requiring a live Notion connection.
+ *
+ * <p>Tests annotated with {@code @NotionLiveTest} are skipped by default. To run them, set the
+ * system property {@code -Dnotion.live.tests.enabled=true}.
+ *
+ * <p>Combine with {@link com.github.javydreamercsw.management.extension.NotionTestCleanupExtension}
+ * to ensure any pages created during the test are archived afterwards.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("notion-live")
+@EnabledIfSystemProperty(
+    named = "notion.live.tests.enabled",
+    matches = "true",
+    disabledReason =
+        "Live Notion tests disabled by default. Run with -Dnotion.live.tests.enabled=true to"
+            + " enable.")
+public @interface NotionLiveTest {}

--- a/src/test/java/com/github/javydreamercsw/management/extension/NotionTestCleanupExtension.java
+++ b/src/test/java/com/github/javydreamercsw/management/extension/NotionTestCleanupExtension.java
@@ -1,0 +1,102 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.extension;
+
+import com.github.javydreamercsw.base.util.EnvironmentVariableUtil;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+import notion.api.v1.NotionClient;
+import notion.api.v1.http.OkHttp4Client;
+import notion.api.v1.request.pages.UpdatePageRequest;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension that archives Notion pages created during tests.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * @ExtendWith(NotionTestCleanupExtension.class)
+ * class MyNotionTest {
+ *   void myTest() {
+ *     String pageId = notionClient.createPage(...).getId();
+ *     NotionTestCleanupExtension.trackPageId(pageId);
+ *     // ... assertions ...
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>Cleanup only runs when a real {@code NOTION_TOKEN} is present in the environment, so mocked
+ * tests are unaffected.
+ */
+@Slf4j
+public class NotionTestCleanupExtension implements BeforeAllCallback, AfterAllCallback {
+
+  private static final Set<String> TRACKED_PAGE_IDS = ConcurrentHashMap.newKeySet();
+
+  /**
+   * Registers a Notion page ID for cleanup after the test class completes. Safe to call even when
+   * running with a mocked Notion client — cleanup is skipped if no real token is available.
+   */
+  public static void trackPageId(final String pageId) {
+    if (pageId != null && !pageId.isBlank()) {
+      TRACKED_PAGE_IDS.add(pageId);
+    }
+  }
+
+  @Override
+  public void beforeAll(final ExtensionContext context) {
+    TRACKED_PAGE_IDS.clear();
+  }
+
+  @Override
+  public void afterAll(final ExtensionContext context) {
+    if (TRACKED_PAGE_IDS.isEmpty()) {
+      return;
+    }
+
+    String token = EnvironmentVariableUtil.getNotionToken();
+    if (token == null || token.isBlank()) {
+      log.debug(
+          "Skipping Notion test cleanup — no NOTION_TOKEN found ({} page IDs tracked but not"
+              + " archived)",
+          TRACKED_PAGE_IDS.size());
+      TRACKED_PAGE_IDS.clear();
+      return;
+    }
+
+    log.info("Archiving {} test Notion page(s) created during tests", TRACKED_PAGE_IDS.size());
+    try (NotionClient client = new NotionClient(token)) {
+      client.setHttpClient(new OkHttp4Client(30_000, 30_000, 30_000));
+      for (String pageId : TRACKED_PAGE_IDS) {
+        try {
+          client.updatePage(new UpdatePageRequest(pageId, null, true, null, null));
+          log.info("Archived test Notion page: {}", pageId);
+        } catch (Exception e) {
+          log.warn("Failed to archive test Notion page {}: {}", pageId, e.getMessage());
+        }
+      }
+    } catch (Exception e) {
+      log.warn("Failed to create Notion client for cleanup: {}", e.getMessage());
+    } finally {
+      TRACKED_PAGE_IDS.clear();
+    }
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/NotionTokenSettingIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/NotionTokenSettingIT.java
@@ -30,7 +30,7 @@ import org.springframework.test.context.TestPropertySource;
 
 @NotionLiveTest
 @TestPropertySource(properties = {"notion.sync.enabled=true", "test.mock.notion-handler=false"})
-class NotionTokenSettingTest extends AbstractMockUserIntegrationTest {
+class NotionTokenSettingIT extends AbstractMockUserIntegrationTest {
 
   @Autowired private GameSettingService gameSettingService;
   @Autowired private NotionHandler notionHandler;

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/NotionTokenSettingTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/NotionTokenSettingTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.javydreamercsw.base.ai.notion.NotionHandler;
+import com.github.javydreamercsw.management.annotation.NotionLiveTest;
 import com.github.javydreamercsw.management.service.GameSettingService;
 import com.github.javydreamercsw.management.test.AbstractMockUserIntegrationTest;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
+@NotionLiveTest
 @TestPropertySource(properties = {"notion.sync.enabled=true", "test.mock.notion-handler=false"})
 class NotionTokenSettingTest extends AbstractMockUserIntegrationTest {
 

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/FactionNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/FactionNotionSyncServiceIT.java
@@ -26,6 +26,7 @@ import com.github.javydreamercsw.base.ai.notion.NotionHandler;
 import com.github.javydreamercsw.management.ManagementIntegrationTest;
 import com.github.javydreamercsw.management.domain.faction.Faction;
 import com.github.javydreamercsw.management.domain.faction.FactionRepository;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.FactionNotionSyncService;
 import java.util.UUID;
 import notion.api.v1.NotionClient;
@@ -33,6 +34,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -41,6 +43,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class FactionNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private FactionRepository factionRepository;
@@ -60,6 +63,7 @@ class FactionNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/FactionRivalryNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/FactionRivalryNotionSyncServiceIT.java
@@ -28,6 +28,7 @@ import com.github.javydreamercsw.management.domain.faction.Faction;
 import com.github.javydreamercsw.management.domain.faction.FactionRepository;
 import com.github.javydreamercsw.management.domain.faction.FactionRivalry;
 import com.github.javydreamercsw.management.domain.faction.FactionRivalryRepository;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.FactionRivalryNotionSyncService;
 import java.time.Instant;
 import java.util.UUID;
@@ -36,6 +37,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -44,6 +46,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class FactionRivalryNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private FactionRivalryRepository factionRivalryRepository;
@@ -64,6 +67,7 @@ class FactionRivalryNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/InjuryNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/InjuryNotionSyncServiceIT.java
@@ -29,6 +29,7 @@ import com.github.javydreamercsw.management.domain.injury.InjuryRepository;
 import com.github.javydreamercsw.management.domain.injury.InjurySeverity;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.InjuryNotionSyncService;
 import java.time.Instant;
 import java.util.UUID;
@@ -37,6 +38,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -45,6 +47,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class InjuryNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private InjuryRepository injuryRepository;
@@ -65,6 +68,7 @@ class InjuryNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/NpcNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/NpcNotionSyncServiceIT.java
@@ -27,6 +27,7 @@ import com.github.javydreamercsw.management.ManagementIntegrationTest;
 import com.github.javydreamercsw.management.domain.npc.Npc;
 import com.github.javydreamercsw.management.domain.npc.NpcRepository;
 import com.github.javydreamercsw.management.domain.npc.NpcType;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.NpcNotionSyncService;
 import java.util.UUID;
 import notion.api.v1.NotionClient;
@@ -34,6 +35,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -42,6 +44,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class NpcNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private NpcRepository npcRepository;
@@ -61,6 +64,7 @@ class NpcNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/RivalryNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/RivalryNotionSyncServiceIT.java
@@ -28,6 +28,7 @@ import com.github.javydreamercsw.management.domain.rivalry.Rivalry;
 import com.github.javydreamercsw.management.domain.rivalry.RivalryRepository;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.RivalryNotionSyncService;
 import java.time.Instant;
 import java.util.UUID;
@@ -36,6 +37,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -44,6 +46,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class RivalryNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private RivalryRepository rivalryRepository;
@@ -64,6 +67,7 @@ class RivalryNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/SeasonNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/SeasonNotionSyncServiceIT.java
@@ -26,6 +26,7 @@ import com.github.javydreamercsw.base.ai.notion.NotionHandler;
 import com.github.javydreamercsw.management.ManagementIntegrationTest;
 import com.github.javydreamercsw.management.domain.season.Season;
 import com.github.javydreamercsw.management.domain.season.SeasonRepository;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.SeasonNotionSyncService;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -35,6 +36,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -43,6 +45,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class SeasonNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private SeasonRepository seasonRepository;
@@ -62,6 +65,7 @@ class SeasonNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/SegmentNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/SegmentNotionSyncServiceIT.java
@@ -45,6 +45,7 @@ import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerStateRepository;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.SegmentNotionSyncService;
 import com.github.javydreamercsw.management.service.wrestler.WrestlerService;
 import java.time.Instant;
@@ -55,6 +56,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -63,6 +65,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class SegmentNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private SegmentRepository segmentRepository;
@@ -90,6 +93,7 @@ class SegmentNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/ShowNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/ShowNotionSyncServiceIT.java
@@ -32,6 +32,7 @@ import com.github.javydreamercsw.management.domain.show.template.ShowTemplate;
 import com.github.javydreamercsw.management.domain.show.template.ShowTemplateRepository;
 import com.github.javydreamercsw.management.domain.show.type.ShowType;
 import com.github.javydreamercsw.management.domain.show.type.ShowTypeRepository;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.ShowNotionSyncService;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -41,6 +42,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -49,6 +51,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class ShowNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private ShowRepository showRepository;
@@ -71,6 +74,7 @@ class ShowNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/ShowTemplateNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/ShowTemplateNotionSyncServiceIT.java
@@ -28,6 +28,7 @@ import com.github.javydreamercsw.management.domain.show.template.ShowTemplate;
 import com.github.javydreamercsw.management.domain.show.template.ShowTemplateRepository;
 import com.github.javydreamercsw.management.domain.show.type.ShowType;
 import com.github.javydreamercsw.management.domain.show.type.ShowTypeRepository;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.ShowTemplateNotionSyncService;
 import java.util.UUID;
 import notion.api.v1.NotionClient;
@@ -35,6 +36,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -43,6 +45,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class ShowTemplateNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private ShowTemplateRepository showTemplateRepository;
@@ -63,6 +66,7 @@ class ShowTemplateNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/ShowTypeNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/ShowTypeNotionSyncServiceIT.java
@@ -26,6 +26,7 @@ import com.github.javydreamercsw.base.ai.notion.NotionHandler;
 import com.github.javydreamercsw.management.ManagementIntegrationTest;
 import com.github.javydreamercsw.management.domain.show.type.ShowType;
 import com.github.javydreamercsw.management.domain.show.type.ShowTypeRepository;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.ShowTypeNotionSyncService;
 import java.util.UUID;
 import notion.api.v1.NotionClient;
@@ -33,6 +34,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -41,6 +43,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class ShowTypeNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private ShowTypeRepository showTypeRepository;
@@ -60,6 +63,7 @@ class ShowTypeNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/TeamNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/TeamNotionSyncServiceIT.java
@@ -28,6 +28,7 @@ import com.github.javydreamercsw.management.domain.team.Team;
 import com.github.javydreamercsw.management.domain.team.TeamRepository;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.TeamNotionSyncService;
 import java.util.UUID;
 import notion.api.v1.NotionClient;
@@ -35,6 +36,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -43,6 +45,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class TeamNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private TeamRepository teamRepository;
@@ -63,6 +66,7 @@ class TeamNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/TitleNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/TitleNotionSyncServiceIT.java
@@ -27,6 +27,7 @@ import com.github.javydreamercsw.management.ManagementIntegrationTest;
 import com.github.javydreamercsw.management.domain.title.ChampionshipType;
 import com.github.javydreamercsw.management.domain.title.Title;
 import com.github.javydreamercsw.management.domain.title.TitleRepository;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.TitleNotionSyncService;
 import java.util.UUID;
 import notion.api.v1.NotionClient;
@@ -34,6 +35,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -42,6 +44,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class TitleNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private TitleRepository titleRepository;
@@ -61,6 +64,7 @@ class TitleNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/TitleReignNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/TitleReignNotionSyncServiceIT.java
@@ -31,6 +31,7 @@ import com.github.javydreamercsw.management.domain.title.TitleReignRepository;
 import com.github.javydreamercsw.management.domain.title.TitleRepository;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.TitleReignNotionSyncService;
 import java.time.Instant;
 import java.util.UUID;
@@ -39,6 +40,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -47,6 +49,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class TitleReignNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private TitleReignRepository titleReignRepository;
@@ -68,6 +71,7 @@ class TitleReignNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/WrestlerNotionSyncServiceIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/sync/entity/notion/outgoing/WrestlerNotionSyncServiceIT.java
@@ -29,6 +29,7 @@ import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerStateRepository;
+import com.github.javydreamercsw.management.extension.NotionTestCleanupExtension;
 import com.github.javydreamercsw.management.service.sync.entity.notion.WrestlerNotionSyncService;
 import com.github.javydreamercsw.management.service.wrestler.WrestlerService;
 import java.util.UUID;
@@ -37,6 +38,7 @@ import notion.api.v1.model.pages.Page;
 import notion.api.v1.request.pages.CreatePageRequest;
 import notion.api.v1.request.pages.UpdatePageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -45,6 +47,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@ExtendWith(NotionTestCleanupExtension.class)
 class WrestlerNotionSyncServiceIT extends ManagementIntegrationTest {
 
   @Autowired private WrestlerRepository wrestlerRepository;
@@ -67,6 +70,7 @@ class WrestlerNotionSyncServiceIT extends ManagementIntegrationTest {
 
     String newPageId = UUID.randomUUID().toString();
     when(newPage.getId()).thenReturn(newPageId);
+    NotionTestCleanupExtension.trackPageId(newPageId);
 
     when(notionClient.createPage(any(CreatePageRequest.class))).thenReturn(newPage);
     when(notionClient.updatePage(any(UpdatePageRequest.class))).thenReturn(newPage);

--- a/src/test/java/com/github/javydreamercsw/management/test/AbstractIntegrationTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/test/AbstractIntegrationTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javydreamercsw.Application;
 import com.github.javydreamercsw.TestUtils;
 import com.github.javydreamercsw.base.ai.SegmentNarrationService;
+import com.github.javydreamercsw.base.ai.notion.NotionHandler;
 import com.github.javydreamercsw.base.config.TestSecurityContextConfig;
 import com.github.javydreamercsw.base.domain.account.Account;
 import com.github.javydreamercsw.base.domain.account.AccountRepository;
@@ -104,6 +105,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -143,6 +145,15 @@ public abstract class AbstractIntegrationTest {
 
   @MockitoBean protected VaadinDefaultRequestCache vaadinDefaultRequestCache;
   @MockitoBean protected RequestUtil requestUtil;
+
+  /**
+   * The shared NotionHandler mock provided by TestNotionConfiguration. Injected here so it can be
+   * reset before each test, preventing stub state from leaking across test classes that share the
+   * same Spring context. When a test class uses @MockitoBean NotionHandler, that bean replaces this
+   * one and is already reset automatically by Spring Boot's MockitoResetTestExecutionListener.
+   */
+  @Autowired(required = false)
+  protected NotionHandler sharedNotionHandlerMock;
 
   @Autowired protected AuthenticationContext authenticationContext;
   @Autowired protected ApplicationContext applicationContext;
@@ -253,6 +264,14 @@ public abstract class AbstractIntegrationTest {
   @BeforeEach
   public void baseSetUp() {
     log.debug("AbstractIntegrationTest.baseSetUp() called for {}", this.getClass().getSimpleName());
+
+    // Reset the shared NotionHandler mock so stub state does not leak across test classes that
+    // share the same Spring context. @MockitoBean tests manage their own mock lifecycle and are
+    // unaffected — Mockito.reset() on an already-fresh mock is a no-op.
+    if (sharedNotionHandlerMock != null
+        && Mockito.mockingDetails(sharedNotionHandlerMock).isMock()) {
+      Mockito.reset(sharedNotionHandlerMock);
+    }
 
     // 1. Capture original authentication
     Authentication originalAuth = SecurityContextHolder.getContext().getAuthentication();


### PR DESCRIPTION
- Add @NotionLiveTest annotation (opt-in via -Dnotion.live.tests.enabled=true)
- Add NotionTestCleanupExtension to archive tracked Notion pages after test runs
- Apply @ExtendWith(NotionTestCleanupExtension) + trackPageId() to all 14 outgoing IT tests
- Reset shared NotionHandler mock in AbstractIntegrationTest.baseSetUp() to prevent stub leaks
- Apply @NotionLiveTest to NotionTokenSettingTest which uses a real NotionHandler