### PR TITLE
feat(rivalry-lifecycle): configurable rivalry resolution, decay, and max duration (ATW-u6sy)

### DIFF
--- a/src/main/java/com/github/javydreamercsw/management/domain/rivalry/Rivalry.java
+++ b/src/main/java/com/github/javydreamercsw/management/domain/rivalry/Rivalry.java
@@ -127,16 +127,17 @@ public class Rivalry extends AbstractSyncableEntity<Long> {
   }
 
   /**
-   * Attempt to resolve the rivalry with dice roll. ATW Rule: Both roll d20 → total >30 = rivalry
-   * ends
+   * Attempt to resolve the rivalry with dice roll. ATW Rule: Both roll d20 → total > threshold =
+   * rivalry ends.
    */
-  public boolean attemptResolution(final int wrestler1Roll, final int wrestler2Roll) {
+  public boolean attemptResolution(
+      final int wrestler1Roll, final int wrestler2Roll, final int threshold) {
     if (!canAttemptResolution()) {
       return false;
     }
 
     int totalRoll = wrestler1Roll + wrestler2Roll;
-    boolean resolved = totalRoll > 30;
+    boolean resolved = totalRoll > threshold;
 
     if (resolved) {
       endRivalry(
@@ -158,6 +159,11 @@ public class Rivalry extends AbstractSyncableEntity<Long> {
     heatEvents.add(event);
 
     return resolved;
+  }
+
+  /** Backward-compatible overload using the default hardcoded threshold of 30. */
+  public boolean attemptResolution(final int wrestler1Roll, final int wrestler2Roll) {
+    return attemptResolution(wrestler1Roll, wrestler2Roll, 30);
   }
 
   /** End the rivalry. */

--- a/src/main/java/com/github/javydreamercsw/management/service/GameSettingService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/GameSettingService.java
@@ -42,6 +42,20 @@ public class GameSettingService {
   public static final String WEAR_AND_TEAR_ENABLED_KEY = "wear_and_tear_enabled";
   public static final String STATUS_CARDS_ENABLED_KEY = "status_cards_enabled";
   public static final String NOTION_TOKEN_KEY = "notion_token";
+
+  // Rivalry lifecycle settings
+  public static final String RIVALRY_RESOLUTION_THRESHOLD_PLE_KEY =
+      "rivalry_resolution_threshold_ple";
+  public static final String RIVALRY_RESOLUTION_THRESHOLD_REGULAR_KEY =
+      "rivalry_resolution_threshold_regular";
+  public static final String RIVALRY_RESOLUTION_ON_REGULAR_SHOWS_KEY =
+      "rivalry_resolution_on_regular_shows";
+  public static final String RIVALRY_MAX_DURATION_DAYS_KEY = "rivalry_max_duration_days";
+  public static final String RIVALRY_HEAT_DECAY_ENABLED_KEY = "rivalry_heat_decay_enabled";
+  public static final String RIVALRY_HEAT_DECAY_PER_INTERVAL_KEY =
+      "rivalry_heat_decay_per_interval";
+  public static final String RIVALRY_HEAT_DECAY_INTERVAL_DAYS_KEY =
+      "rivalry_heat_decay_interval_days";
   private final GameSettingRepository repository;
   private final ApplicationEventPublisher eventPublisher;
 
@@ -150,6 +164,111 @@ public class GameSettingService {
       log.info("Game date changed from {} to {}", oldDate, date);
       eventPublisher.publishEvent(new GameDateChangedEvent(this, oldDate, date));
     }
+  }
+
+  @PreAuthorize("permitAll()")
+  public int getRivalryResolutionThresholdPle() {
+    return repository
+        .findById(RIVALRY_RESOLUTION_THRESHOLD_PLE_KEY)
+        .map(GameSetting::getValue)
+        .map(Integer::parseInt)
+        .orElse(30);
+  }
+
+  @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_SYSTEM')")
+  @Transactional
+  public void setRivalryResolutionThresholdPle(final int threshold) {
+    save(RIVALRY_RESOLUTION_THRESHOLD_PLE_KEY, String.valueOf(threshold));
+  }
+
+  @PreAuthorize("permitAll()")
+  public int getRivalryResolutionThresholdRegular() {
+    return repository
+        .findById(RIVALRY_RESOLUTION_THRESHOLD_REGULAR_KEY)
+        .map(GameSetting::getValue)
+        .map(Integer::parseInt)
+        .orElse(35);
+  }
+
+  @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_SYSTEM')")
+  @Transactional
+  public void setRivalryResolutionThresholdRegular(final int threshold) {
+    save(RIVALRY_RESOLUTION_THRESHOLD_REGULAR_KEY, String.valueOf(threshold));
+  }
+
+  @PreAuthorize("permitAll()")
+  public boolean isRivalryResolutionOnRegularShowsEnabled() {
+    return repository
+        .findById(RIVALRY_RESOLUTION_ON_REGULAR_SHOWS_KEY)
+        .map(GameSetting::getValue)
+        .map(Boolean::parseBoolean)
+        .orElse(false);
+  }
+
+  @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_SYSTEM')")
+  @Transactional
+  public void setRivalryResolutionOnRegularShowsEnabled(final boolean enabled) {
+    save(RIVALRY_RESOLUTION_ON_REGULAR_SHOWS_KEY, String.valueOf(enabled));
+  }
+
+  @PreAuthorize("permitAll()")
+  public int getRivalryMaxDurationDays() {
+    return repository
+        .findById(RIVALRY_MAX_DURATION_DAYS_KEY)
+        .map(GameSetting::getValue)
+        .map(Integer::parseInt)
+        .orElse(0);
+  }
+
+  @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_SYSTEM')")
+  @Transactional
+  public void setRivalryMaxDurationDays(final int days) {
+    save(RIVALRY_MAX_DURATION_DAYS_KEY, String.valueOf(days));
+  }
+
+  @PreAuthorize("permitAll()")
+  public boolean isRivalryHeatDecayEnabled() {
+    return repository
+        .findById(RIVALRY_HEAT_DECAY_ENABLED_KEY)
+        .map(GameSetting::getValue)
+        .map(Boolean::parseBoolean)
+        .orElse(false);
+  }
+
+  @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_SYSTEM')")
+  @Transactional
+  public void setRivalryHeatDecayEnabled(final boolean enabled) {
+    save(RIVALRY_HEAT_DECAY_ENABLED_KEY, String.valueOf(enabled));
+  }
+
+  @PreAuthorize("permitAll()")
+  public int getRivalryHeatDecayPerInterval() {
+    return repository
+        .findById(RIVALRY_HEAT_DECAY_PER_INTERVAL_KEY)
+        .map(GameSetting::getValue)
+        .map(Integer::parseInt)
+        .orElse(1);
+  }
+
+  @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_SYSTEM')")
+  @Transactional
+  public void setRivalryHeatDecayPerInterval(final int amount) {
+    save(RIVALRY_HEAT_DECAY_PER_INTERVAL_KEY, String.valueOf(amount));
+  }
+
+  @PreAuthorize("permitAll()")
+  public int getRivalryHeatDecayIntervalDays() {
+    return repository
+        .findById(RIVALRY_HEAT_DECAY_INTERVAL_DAYS_KEY)
+        .map(GameSetting::getValue)
+        .map(Integer::parseInt)
+        .orElse(7);
+  }
+
+  @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_SYSTEM')")
+  @Transactional
+  public void setRivalryHeatDecayIntervalDays(final int days) {
+    save(RIVALRY_HEAT_DECAY_INTERVAL_DAYS_KEY, String.valueOf(days));
   }
 
   @PreAuthorize("permitAll()")

--- a/src/main/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationService.java
@@ -84,7 +84,7 @@ public class SegmentAdjudicationService {
   private final RingsideActionService ringsideActionService;
   private final RingsideAiService ringsideAiService;
   private final RetirementService retirementService;
-  private final GameSettingService gameSettingService;
+  final GameSettingService gameSettingService;
   private final WrestlerRelationshipService relationshipService;
   private final WrestlerStatusService wrestlerStatusService;
   private final UniverseContextService universeContextService;
@@ -436,31 +436,53 @@ public class SegmentAdjudicationService {
       }
     }
 
-    // Attempt to resolve feuds after PLE matches
-    if (segment.getShow().isPremiumLiveEvent()) {
-      log.info("Attempting to resolve feuds after PLE match: {}", segment.getShow().getName());
+    // Attempt to resolve feuds and rivalries after qualifying matches.
+    // PLEs always trigger; regular shows only when the setting is enabled.
+    boolean isPle = segment.getShow().isPremiumLiveEvent();
+    boolean regularResolutionEnabled =
+        gameSettingService.isRivalryResolutionOnRegularShowsEnabled();
+
+    if (isPle || regularResolutionEnabled) {
+      int threshold =
+          isPle
+              ? gameSettingService.getRivalryResolutionThresholdPle()
+              : gameSettingService.getRivalryResolutionThresholdRegular();
+
+      log.info(
+          "Attempting rivalry/feud resolution after {} match: {} (threshold: {})",
+          isPle ? "PLE" : "regular",
+          segment.getShow().getName(),
+          threshold);
+
       for (Wrestler wrestler : segment.getWrestlers()) {
         List<MultiWrestlerFeud> feuds = feudService.getActiveFeudsForWrestler(wrestler.getId());
         for (MultiWrestlerFeud feud : feuds) {
           feudResolutionService.attemptFeudResolution(feud);
         }
       }
+
       // If the AI tagged a specific rivalry, attempt resolution on it directly.
       if (segment.getRivalryId() != null) {
         DiceBag diceBag = new DiceBag(20);
-        rivalryService.attemptResolution(segment.getRivalryId(), diceBag.roll(), diceBag.roll());
+        rivalryService.attemptResolution(
+            segment.getRivalryId(), diceBag.roll(), diceBag.roll(), threshold);
         log.info(
-            "Attempted resolution of AI-tagged rivalry {} after PLE segment {}",
+            "Attempted resolution of AI-tagged rivalry {} after {} segment {}",
             segment.getRivalryId(),
+            isPle ? "PLE" : "regular",
             segment.getId());
       } else {
         // Fall back to generic pair-scan when no rivalry was explicitly tagged.
         switch (segment.getSegmentType().getName()) {
           case "Tag Team":
-            attemptRivalryResolution(segment.getWrestlers().get(0), segment.getWrestlers().get(2));
-            attemptRivalryResolution(segment.getWrestlers().get(0), segment.getWrestlers().get(3));
-            attemptRivalryResolution(segment.getWrestlers().get(1), segment.getWrestlers().get(2));
-            attemptRivalryResolution(segment.getWrestlers().get(1), segment.getWrestlers().get(3));
+            attemptRivalryResolution(
+                segment.getWrestlers().get(0), segment.getWrestlers().get(2), threshold);
+            attemptRivalryResolution(
+                segment.getWrestlers().get(0), segment.getWrestlers().get(3), threshold);
+            attemptRivalryResolution(
+                segment.getWrestlers().get(1), segment.getWrestlers().get(2), threshold);
+            attemptRivalryResolution(
+                segment.getWrestlers().get(1), segment.getWrestlers().get(3), threshold);
             break;
           case "Abu Dhabi Rumble":
           case "One on One":
@@ -471,7 +493,7 @@ public class SegmentAdjudicationService {
               Wrestler baseWrestler = winners.isEmpty() ? wrestlers.get(0) : winners.get(0);
               for (Wrestler other : wrestlers) {
                 if (!baseWrestler.equals(other)) {
-                  attemptRivalryResolution(baseWrestler, other);
+                  attemptRivalryResolution(baseWrestler, other, threshold);
                 }
               }
             }
@@ -815,13 +837,15 @@ public class SegmentAdjudicationService {
     }
   }
 
-  private void attemptRivalryResolution(@NonNull final Wrestler w1, @NonNull final Wrestler w2) {
+  private void attemptRivalryResolution(
+      @NonNull final Wrestler w1, @NonNull final Wrestler w2, final int threshold) {
     DiceBag diceBag = new DiceBag(20);
     Optional<Rivalry> rivalryBetweenWrestlers =
         rivalryService.getRivalryBetweenWrestlers(w1.getId(), w2.getId());
     rivalryBetweenWrestlers.ifPresent(
         rivalry ->
-            rivalryService.attemptResolution(rivalry.getId(), diceBag.roll(), diceBag.roll()));
+            rivalryService.attemptResolution(
+                rivalry.getId(), diceBag.roll(), diceBag.roll(), threshold));
   }
 
   private void applyWearAndTear(@NonNull final Segment segment) {

--- a/src/main/java/com/github/javydreamercsw/management/service/rivalry/RivalryDecayService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/rivalry/RivalryDecayService.java
@@ -1,0 +1,149 @@
+/*
+* Copyright (C) 2025 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.rivalry;
+
+import com.github.javydreamercsw.management.domain.rivalry.HeatEvent;
+import com.github.javydreamercsw.management.domain.rivalry.Rivalry;
+import com.github.javydreamercsw.management.domain.rivalry.RivalryRepository;
+import com.github.javydreamercsw.management.service.GameSettingService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RivalryDecayService {
+
+  private final RivalryRepository rivalryRepository;
+  private final GameSettingService gameSettingService;
+  private final Clock clock;
+
+  /** Runs nightly to apply heat decay and auto-close stale rivalries. */
+  @Scheduled(cron = "0 0 3 * * *")
+  @Transactional
+  public void runDailyMaintenance() {
+    elevateToSystem();
+    try {
+      applyHeatDecay();
+      closeExpiredRivalries();
+    } finally {
+      SecurityContextHolder.clearContext();
+    }
+  }
+
+  /** Decays heat on rivalries that have had no activity for the configured interval. */
+  @Transactional
+  public void applyHeatDecay() {
+    if (!gameSettingService.isRivalryHeatDecayEnabled()) {
+      return;
+    }
+
+    int decayAmount = gameSettingService.getRivalryHeatDecayPerInterval();
+    int intervalDays = gameSettingService.getRivalryHeatDecayIntervalDays();
+    Instant cutoff = Instant.now(clock).minus(intervalDays, ChronoUnit.DAYS);
+
+    List<Rivalry> candidates = rivalryRepository.findByIsActiveTrue();
+    int decayed = 0;
+    for (Rivalry rivalry : candidates) {
+      if (rivalry.getHeat() <= 0) {
+        continue;
+      }
+      Instant lastActivity = latestHeatEventDate(rivalry);
+      if (lastActivity == null || lastActivity.isBefore(cutoff)) {
+        int oldHeat = rivalry.getHeat();
+        int newHeat = Math.max(0, oldHeat - decayAmount);
+        rivalry.setHeat(newHeat);
+
+        HeatEvent event = new HeatEvent();
+        event.setRivalry(rivalry);
+        event.setHeatChange(-decayAmount);
+        event.setReason("Automatic heat decay");
+        event.setEventDate(Instant.now(clock));
+        event.setHeatAfterEvent(newHeat);
+        rivalry.getHeatEvents().add(event);
+
+        rivalryRepository.save(rivalry);
+        decayed++;
+        log.debug(
+            "Decayed rivalry {} heat {} → {} (last activity: {})",
+            rivalry.getId(),
+            oldHeat,
+            newHeat,
+            lastActivity);
+      }
+    }
+    if (decayed > 0) {
+      log.info(
+          "Heat decay applied to {} rivalries (amount: {}, interval: {}d)",
+          decayed,
+          decayAmount,
+          intervalDays);
+    }
+  }
+
+  /** Auto-closes rivalries that have exceeded the configured maximum duration. */
+  @Transactional
+  public void closeExpiredRivalries() {
+    int maxDays = gameSettingService.getRivalryMaxDurationDays();
+    if (maxDays <= 0) {
+      return;
+    }
+
+    Instant expiryDate = Instant.now(clock).minus(maxDays, ChronoUnit.DAYS);
+    List<Rivalry> candidates = rivalryRepository.findByIsActiveTrue();
+    int closed = 0;
+    for (Rivalry rivalry : candidates) {
+      if (rivalry.getStartedDate() != null && rivalry.getStartedDate().isBefore(expiryDate)) {
+        rivalry.endRivalry("Exceeded maximum rivalry duration (%dd)".formatted(maxDays));
+        rivalryRepository.save(rivalry);
+        closed++;
+        log.info(
+            "Auto-closed rivalry {} (started: {}, max duration: {}d)",
+            rivalry.getId(),
+            rivalry.getStartedDate(),
+            maxDays);
+      }
+    }
+    if (closed > 0) {
+      log.info("Auto-closed {} expired rivalries (max duration: {}d)", closed, maxDays);
+    }
+  }
+
+  private Instant latestHeatEventDate(final Rivalry rivalry) {
+    return rivalry.getHeatEvents().stream()
+        .map(HeatEvent::getEventDate)
+        .max(Instant::compareTo)
+        .orElse(null);
+  }
+
+  private void elevateToSystem() {
+    var auth =
+        new UsernamePasswordAuthenticationToken(
+            "system", null, List.of(new SimpleGrantedAuthority("ROLE_SYSTEM")));
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+}

--- a/src/main/java/com/github/javydreamercsw/management/service/rivalry/RivalryService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/rivalry/RivalryService.java
@@ -26,6 +26,7 @@ import com.github.javydreamercsw.management.event.HeatChangeEvent;
 import com.github.javydreamercsw.management.event.RivalryCompletedEvent;
 import com.github.javydreamercsw.management.event.RivalryContinuesEvent;
 import com.github.javydreamercsw.management.mapper.RivalryMapper;
+import com.github.javydreamercsw.management.service.GameSettingService;
 import com.github.javydreamercsw.management.service.resolution.ResolutionResult;
 import java.time.Clock;
 import java.time.Instant;
@@ -54,6 +55,7 @@ public class RivalryService {
   @Autowired @Getter private RivalryMapper rivalryMapper;
   @Autowired private Clock clock;
   @Autowired private ApplicationEventPublisher eventPublisher;
+  @Autowired private GameSettingService gameSettingService;
 
   /** Create a new rivalry between two wrestlers. */
   @PreAuthorize(
@@ -152,7 +154,7 @@ public class RivalryService {
     return rivalryOpt.flatMap(rivalry -> addHeat(rivalry.getId(), heatGain, reason));
   }
 
-  /** Attempt to resolve a rivalry with dice rolls. */
+  /** Attempt to resolve a rivalry at a PLE (uses the configured PLE threshold). */
   @PreAuthorize(
       "hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_BOOKER') or hasAuthority('ROLE_SYSTEM')")
   @org.springframework.cache.annotation.CacheEvict(
@@ -162,6 +164,24 @@ public class RivalryService {
       @NonNull final Long rivalryId,
       @NonNull final Integer wrestler1Roll,
       @NonNull final Integer wrestler2Roll) {
+    return attemptResolution(
+        rivalryId,
+        wrestler1Roll,
+        wrestler2Roll,
+        gameSettingService.getRivalryResolutionThresholdPle());
+  }
+
+  /** Attempt to resolve a rivalry with an explicit threshold. */
+  @PreAuthorize(
+      "hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_BOOKER') or hasAuthority('ROLE_SYSTEM')")
+  @org.springframework.cache.annotation.CacheEvict(
+      value = com.github.javydreamercsw.management.config.CacheConfig.RIVALRIES_CACHE,
+      allEntries = true)
+  public ResolutionResult<Rivalry> attemptResolution(
+      @NonNull final Long rivalryId,
+      @NonNull final Integer wrestler1Roll,
+      @NonNull final Integer wrestler2Roll,
+      final int threshold) {
     Optional<Rivalry> rivalryOpt = rivalryRepository.findById(rivalryId);
 
     if (rivalryOpt.isEmpty()) {
@@ -181,12 +201,11 @@ public class RivalryService {
           0);
     }
 
-    // Use provided rolls or generate random ones
     int roll1 = wrestler1Roll;
     int roll2 = wrestler2Roll;
     int total = roll1 + roll2;
 
-    boolean resolved = rivalry.attemptResolution(roll1, roll2);
+    boolean resolved = rivalry.attemptResolution(roll1, roll2, threshold);
 
     if (resolved) {
       rivalry.endRivalry("Rivalry resolved successfully");

--- a/src/main/java/com/github/javydreamercsw/management/ui/view/GameSettingsView.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/view/GameSettingsView.java
@@ -22,6 +22,7 @@ import com.github.javydreamercsw.management.service.GameSettingService;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.NotificationVariant;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
@@ -168,6 +169,102 @@ public class GameSettingsView extends VerticalLayout {
               .addThemeVariants(NotificationVariant.LUMO_SUCCESS);
         });
 
+    // ── Rivalry Configuration ──────────────────────────────────────────────────
+    IntegerField pleThreshold = new IntegerField("PLE Resolution Threshold (2d20 must exceed)");
+    pleThreshold.setMin(2);
+    pleThreshold.setMax(40);
+    pleThreshold.setStepButtonsVisible(true);
+    pleThreshold.setValue(gameSettingService.getRivalryResolutionThresholdPle());
+    pleThreshold.addValueChangeListener(
+        event -> {
+          gameSettingService.setRivalryResolutionThresholdPle(event.getValue());
+          Notification.show("PLE resolution threshold updated to: " + event.getValue())
+              .addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+        });
+
+    IntegerField regularThreshold =
+        new IntegerField("Regular Show Resolution Threshold (2d20 must exceed)");
+    regularThreshold.setMin(2);
+    regularThreshold.setMax(40);
+    regularThreshold.setStepButtonsVisible(true);
+    regularThreshold.setValue(gameSettingService.getRivalryResolutionThresholdRegular());
+    regularThreshold.addValueChangeListener(
+        event -> {
+          gameSettingService.setRivalryResolutionThresholdRegular(event.getValue());
+          Notification.show("Regular show resolution threshold updated to: " + event.getValue())
+              .addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+        });
+
+    Checkbox resolutionOnRegular =
+        new Checkbox("Allow rivalry resolution on regular (non-PLE) shows");
+    resolutionOnRegular.setValue(gameSettingService.isRivalryResolutionOnRegularShowsEnabled());
+    resolutionOnRegular.addValueChangeListener(
+        event -> {
+          gameSettingService.setRivalryResolutionOnRegularShowsEnabled(event.getValue());
+          Notification.show(
+                  "Regular show resolution " + (event.getValue() ? "enabled" : "disabled"))
+              .addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+        });
+
+    IntegerField maxDuration = new IntegerField("Max Rivalry Duration (days, 0 = unlimited)");
+    maxDuration.setMin(0);
+    maxDuration.setStepButtonsVisible(true);
+    maxDuration.setValue(gameSettingService.getRivalryMaxDurationDays());
+    maxDuration.addValueChangeListener(
+        event -> {
+          gameSettingService.setRivalryMaxDurationDays(event.getValue());
+          Notification.show(
+                  event.getValue() == 0
+                      ? "Max rivalry duration disabled"
+                      : "Max rivalry duration set to " + event.getValue() + " days")
+              .addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+        });
+
+    Checkbox heatDecayEnabled = new Checkbox("Enable automatic heat decay");
+    heatDecayEnabled.setValue(gameSettingService.isRivalryHeatDecayEnabled());
+    heatDecayEnabled.addValueChangeListener(
+        event -> {
+          gameSettingService.setRivalryHeatDecayEnabled(event.getValue());
+          Notification.show("Heat decay " + (event.getValue() ? "enabled" : "disabled"))
+              .addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+        });
+
+    IntegerField decayAmount = new IntegerField("Heat decay per interval");
+    decayAmount.setMin(1);
+    decayAmount.setMax(10);
+    decayAmount.setStepButtonsVisible(true);
+    decayAmount.setValue(gameSettingService.getRivalryHeatDecayPerInterval());
+    decayAmount.addValueChangeListener(
+        event -> {
+          gameSettingService.setRivalryHeatDecayPerInterval(event.getValue());
+          Notification.show("Heat decay amount updated to: " + event.getValue())
+              .addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+        });
+
+    IntegerField decayInterval = new IntegerField("Heat decay interval (days)");
+    decayInterval.setMin(1);
+    decayInterval.setMax(30);
+    decayInterval.setStepButtonsVisible(true);
+    decayInterval.setValue(gameSettingService.getRivalryHeatDecayIntervalDays());
+    decayInterval.addValueChangeListener(
+        event -> {
+          gameSettingService.setRivalryHeatDecayIntervalDays(event.getValue());
+          Notification.show("Heat decay interval updated to: " + event.getValue() + " days")
+              .addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+        });
+
+    VerticalLayout rivalrySection =
+        new VerticalLayout(
+            new H3("Rivalry Configuration"),
+            pleThreshold,
+            regularThreshold,
+            resolutionOnRegular,
+            maxDuration,
+            heatDecayEnabled,
+            decayAmount,
+            decayInterval);
+    rivalrySection.setPadding(false);
+
     VerticalLayout layout =
         new VerticalLayout(
             gameDatePicker,
@@ -176,7 +273,8 @@ public class GameSettingsView extends VerticalLayout {
             aiNewsEnabled,
             wearAndTearEnabled,
             rumorChance,
-            newsStrategy);
+            newsStrategy,
+            rivalrySection);
 
     add(layout);
   }

--- a/src/main/resources/db/migration/h2/V85__Seed_Rivalry_Lifecycle_Settings.sql
+++ b/src/main/resources/db/migration/h2/V85__Seed_Rivalry_Lifecycle_Settings.sql
@@ -1,0 +1,11 @@
+-- Seed default game_settings for rivalry lifecycle management.
+-- Uses MERGE so re-running on an existing DB is a no-op.
+MERGE INTO game_setting (setting_key, setting_value)
+    KEY (setting_key)
+VALUES ('rivalry_resolution_threshold_ple',      '30'),
+       ('rivalry_resolution_threshold_regular',  '35'),
+       ('rivalry_resolution_on_regular_shows',   'false'),
+       ('rivalry_max_duration_days',             '0'),
+       ('rivalry_heat_decay_enabled',            'false'),
+       ('rivalry_heat_decay_per_interval',       '1'),
+       ('rivalry_heat_decay_interval_days',      '7');

--- a/src/main/resources/db/migration/mysql/V55__Seed_Rivalry_Lifecycle_Settings.sql
+++ b/src/main/resources/db/migration/mysql/V55__Seed_Rivalry_Lifecycle_Settings.sql
@@ -1,0 +1,10 @@
+-- Seed default game_settings for rivalry lifecycle management.
+-- INSERT IGNORE is a no-op if the key already exists.
+INSERT IGNORE INTO game_setting (setting_key, setting_value) VALUES
+    ('rivalry_resolution_threshold_ple',      '30'),
+    ('rivalry_resolution_threshold_regular',  '35'),
+    ('rivalry_resolution_on_regular_shows',   'false'),
+    ('rivalry_max_duration_days',             '0'),
+    ('rivalry_heat_decay_enabled',            'false'),
+    ('rivalry_heat_decay_per_interval',       '1'),
+    ('rivalry_heat_decay_interval_days',      '7');

--- a/src/test/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationServiceTest.java
@@ -113,6 +113,9 @@ class SegmentAdjudicationServiceTest {
   @BeforeEach
   public void setUp() {
     lenient().when(gameSettingService.isWearAndTearEnabled()).thenReturn(true);
+    lenient().when(gameSettingService.isRivalryResolutionOnRegularShowsEnabled()).thenReturn(false);
+    lenient().when(gameSettingService.getRivalryResolutionThresholdPle()).thenReturn(30);
+    lenient().when(gameSettingService.getRivalryResolutionThresholdRegular()).thenReturn(35);
     segmentAdjudicationService =
         new SegmentAdjudicationService(
             rivalryService,
@@ -389,14 +392,14 @@ class SegmentAdjudicationServiceTest {
     when(segment.getRivalryId()).thenReturn(42L);
     when(show.isPremiumLiveEvent()).thenReturn(true);
     when(feudService.getActiveFeudsForWrestler(anyLong())).thenReturn(List.of());
-    when(rivalryService.attemptResolution(anyLong(), anyInt(), anyInt()))
+    when(rivalryService.attemptResolution(anyLong(), anyInt(), anyInt(), anyInt()))
         .thenReturn(
             new com.github.javydreamercsw.management.service.resolution.ResolutionResult<>(
                 false, "not resolved", rivalry, 5, 6, 11));
 
     segmentAdjudicationService.adjudicateMatch(segment);
 
-    verify(rivalryService).attemptResolution(eq(42L), anyInt(), anyInt());
+    verify(rivalryService).attemptResolution(eq(42L), anyInt(), anyInt(), anyInt());
     // Generic pair-scan should NOT run when rivalryId is set
     verify(rivalryService, never()).getRivalryBetweenWrestlers(anyLong(), anyLong());
   }
@@ -414,6 +417,6 @@ class SegmentAdjudicationServiceTest {
     // Generic pair-scan must run for winner vs loser
     verify(rivalryService).getRivalryBetweenWrestlers(eq(1L), eq(2L));
     // Direct resolution must NOT be called with a specific id
-    verify(rivalryService, never()).attemptResolution(anyLong(), anyInt(), anyInt());
+    verify(rivalryService, never()).attemptResolution(anyLong(), anyInt(), anyInt(), anyInt());
   }
 }

--- a/src/test/java/com/github/javydreamercsw/management/service/rivalry/RivalryServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/rivalry/RivalryServiceTest.java
@@ -29,6 +29,7 @@ import com.github.javydreamercsw.management.domain.rivalry.RivalryRepository;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.event.HeatChangeEvent;
+import com.github.javydreamercsw.management.service.GameSettingService;
 import com.github.javydreamercsw.management.service.resolution.ResolutionResult;
 import java.time.Clock;
 import java.time.Instant;
@@ -56,12 +57,14 @@ class RivalryServiceTest {
   @Mock private Clock clock;
   @Mock private Random random;
   @Mock private ApplicationEventPublisher eventPublisher;
+  @Mock private GameSettingService gameSettingService;
 
   @InjectMocks private RivalryService rivalryService;
 
   @BeforeEach
   public void setUp() {
     lenient().when(clock.instant()).thenReturn(Instant.parse("2024-01-01T00:00:00Z"));
+    lenient().when(gameSettingService.getRivalryResolutionThresholdPle()).thenReturn(30);
   }
 
   @Test

--- a/src/test/java/com/github/javydreamercsw/management/ui/view/GameSettingsViewTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/ui/view/GameSettingsViewTest.java
@@ -17,13 +17,18 @@
 package com.github.javydreamercsw.management.ui.view;
 
 import static com.github.mvysny.kaributesting.v10.LocatorJ._get;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.github.javydreamercsw.base.service.theme.ThemeService;
 import com.github.javydreamercsw.management.service.GameSettingService;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.textfield.IntegerField;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -45,6 +50,15 @@ class GameSettingsViewTest extends AbstractViewTest {
     when(themeService.getAvailableThemes()).thenReturn(List.of("light", "dark"));
     when(themeService.getGlobalDefaultTheme()).thenReturn(Optional.of("light"));
 
+    // Rivalry lifecycle defaults
+    when(gameSettingService.getRivalryResolutionThresholdPle()).thenReturn(30);
+    when(gameSettingService.getRivalryResolutionThresholdRegular()).thenReturn(35);
+    when(gameSettingService.isRivalryResolutionOnRegularShowsEnabled()).thenReturn(false);
+    when(gameSettingService.getRivalryMaxDurationDays()).thenReturn(0);
+    when(gameSettingService.isRivalryHeatDecayEnabled()).thenReturn(false);
+    when(gameSettingService.getRivalryHeatDecayPerInterval()).thenReturn(1);
+    when(gameSettingService.getRivalryHeatDecayIntervalDays()).thenReturn(7);
+
     view = new GameSettingsView(gameSettingService, themeService, Optional.empty());
     UI.getCurrent().add(view);
   }
@@ -56,5 +70,150 @@ class GameSettingsViewTest extends AbstractViewTest {
     ComboBox<String> combo =
         _get(view, ComboBox.class, spec -> spec.withId("default-theme-selection"));
     assertTrue(combo.isVisible());
+  }
+
+  // ── Rivalry Configuration — render with defaults ───────────────────────────
+
+  @Test
+  @DisplayName("PLE threshold field renders with default value 30")
+  void rivalryPleThreshold_rendersWithDefault() {
+    IntegerField field =
+        _get(
+            view,
+            IntegerField.class,
+            spec -> spec.withLabel("PLE Resolution Threshold (2d20 must exceed)"));
+    assertEquals(30, field.getValue());
+  }
+
+  @Test
+  @DisplayName("Regular show threshold field renders with default value 35")
+  void rivalryRegularThreshold_rendersWithDefault() {
+    IntegerField field =
+        _get(
+            view,
+            IntegerField.class,
+            spec -> spec.withLabel("Regular Show Resolution Threshold (2d20 must exceed)"));
+    assertEquals(35, field.getValue());
+  }
+
+  @Test
+  @DisplayName("Regular show resolution checkbox renders unchecked by default")
+  void rivalryResolutionOnRegular_rendersUnchecked() {
+    Checkbox cb =
+        _get(
+            view,
+            Checkbox.class,
+            spec -> spec.withLabel("Allow rivalry resolution on regular (non-PLE) shows"));
+    assertFalse(cb.getValue());
+  }
+
+  @Test
+  @DisplayName("Max duration field renders with default value 0")
+  void rivalryMaxDuration_rendersWithDefault() {
+    IntegerField field =
+        _get(
+            view,
+            IntegerField.class,
+            spec -> spec.withLabel("Max Rivalry Duration (days, 0 = unlimited)"));
+    assertEquals(0, field.getValue());
+  }
+
+  @Test
+  @DisplayName("Heat decay enabled checkbox renders unchecked by default")
+  void rivalryHeatDecayEnabled_rendersUnchecked() {
+    Checkbox cb = _get(view, Checkbox.class, spec -> spec.withLabel("Enable automatic heat decay"));
+    assertFalse(cb.getValue());
+  }
+
+  @Test
+  @DisplayName("Heat decay per interval field renders with default value 1")
+  void rivalryDecayAmount_rendersWithDefault() {
+    IntegerField field =
+        _get(view, IntegerField.class, spec -> spec.withLabel("Heat decay per interval"));
+    assertEquals(1, field.getValue());
+  }
+
+  @Test
+  @DisplayName("Heat decay interval field renders with default value 7")
+  void rivalryDecayInterval_rendersWithDefault() {
+    IntegerField field =
+        _get(view, IntegerField.class, spec -> spec.withLabel("Heat decay interval (days)"));
+    assertEquals(7, field.getValue());
+  }
+
+  // ── Rivalry Configuration — saves on change ───────────────────────────────
+
+  @Test
+  @DisplayName("Changing PLE threshold persists via service")
+  void rivalryPleThreshold_savesOnChange() {
+    IntegerField field =
+        _get(
+            view,
+            IntegerField.class,
+            spec -> spec.withLabel("PLE Resolution Threshold (2d20 must exceed)"));
+    field.setValue(25);
+    verify(gameSettingService).setRivalryResolutionThresholdPle(25);
+  }
+
+  @Test
+  @DisplayName("Changing regular show threshold persists via service")
+  void rivalryRegularThreshold_savesOnChange() {
+    IntegerField field =
+        _get(
+            view,
+            IntegerField.class,
+            spec -> spec.withLabel("Regular Show Resolution Threshold (2d20 must exceed)"));
+    field.setValue(32);
+    verify(gameSettingService).setRivalryResolutionThresholdRegular(32);
+  }
+
+  @Test
+  @DisplayName("Toggling regular show resolution persists via service")
+  void rivalryResolutionOnRegular_savesOnChange() {
+    Checkbox cb =
+        _get(
+            view,
+            Checkbox.class,
+            spec -> spec.withLabel("Allow rivalry resolution on regular (non-PLE) shows"));
+    cb.setValue(true);
+    verify(gameSettingService).setRivalryResolutionOnRegularShowsEnabled(true);
+  }
+
+  @Test
+  @DisplayName("Changing max duration persists via service")
+  void rivalryMaxDuration_savesOnChange() {
+    IntegerField field =
+        _get(
+            view,
+            IntegerField.class,
+            spec -> spec.withLabel("Max Rivalry Duration (days, 0 = unlimited)"));
+    field.setValue(90);
+    verify(gameSettingService).setRivalryMaxDurationDays(90);
+  }
+
+  @Test
+  @DisplayName("Toggling heat decay enabled persists via service")
+  void rivalryHeatDecayEnabled_savesOnChange() {
+    Checkbox cb = _get(view, Checkbox.class, spec -> spec.withLabel("Enable automatic heat decay"));
+    cb.setValue(true);
+    verify(gameSettingService).setRivalryHeatDecayEnabled(true);
+  }
+
+  @Test
+  @DisplayName("Changing heat decay per interval persists via service")
+  void rivalryDecayAmount_savesOnChange() {
+    IntegerField field =
+        _get(view, IntegerField.class, spec -> spec.withLabel("Heat decay per interval"));
+    field.setValue(3);
+    verify(gameSettingService).setRivalryHeatDecayPerInterval(3);
+  }
+
+  @Test
+  @DisplayName("Changing heat decay interval persists via service")
+  void rivalryDecayInterval_savesOnChange() {
+    IntegerField field =
+        _get(view, IntegerField.class, spec -> spec.withLabel("Heat decay interval (days)"));
+    field.setValue(14);
+    verify(gameSettingService).setRivalryHeatDecayIntervalDays(14);
   }
 }


### PR DESCRIPTION
Fixes the root cause of 558 stuck active rivalries: resolution was PLE-only, hardcoded at 2d20>30 (13.75% odds), with no decay or expiry safety valve.

- GameSettingService: 7 new configurable rivalry settings with getters/setters (PLE threshold, regular-show threshold, opt-in regular-show resolution, max duration days, heat decay enabled/amount/interval)
- GameSettingsView: Rivalry Configuration section exposing all 7 settings
- Rivalry.attemptResolution(): accepts explicit threshold; backward-compat overload kept
- RivalryService.attemptResolution(): reads PLE threshold from settings; new 4-arg overload
- SegmentAdjudicationService: uses configured thresholds; fires resolution on regular shows when rivalry_resolution_on_regular_shows is enabled
- RivalryDecayService: nightly @Scheduled job — decays heat on idle rivalries, auto-closes rivalries exceeding max duration
- Flyway V85 (H2) / V55 (MySQL): seed all 7 defaults so existing installs behave identically until an admin changes a setting
- Updated RivalryServiceTest and SegmentAdjudicationServiceTest for new signatures