### PR TITLE
feat(ATW-b05c): Unified auto-update system for desktop installers and portable ZIP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -524,7 +524,7 @@ jobs:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
           MAVEN_OPTS: "-Xmx2g -XX:+UseG1GC"
         run: |
-          mvn -B package -Pproduction,desktop \
+          mvn -B package -Pproduction,desktop,launcher \
             -Djpackage.type=${{ matrix.type }} \
             -Djpackage.icon=${{ matrix.icon }} \
             -DskipTests --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -1461,7 +1461,7 @@
                 <configuration>
                   <target>
                     <mkdir dir="${project.build.directory}/jpackage-input"/>
-                    <copy file="${project.build.directory}/${project.build.finalName}.jar" tofile="${project.build.directory}/jpackage-input/${project.build.finalName}-thin.jar"/>
+                    <copy file="${project.build.directory}/atw-launcher-${project.version}.jar" tofile="${project.build.directory}/jpackage-input/atw-launcher-${project.version}.jar"/>
                   </target>
                 </configuration>
               </execution>
@@ -1484,15 +1484,9 @@
                   <vendor>Javier Ortiz Bultron</vendor>
                   <appVersion>${jpackage.appVersion}</appVersion>
                   <input>${project.build.directory}/jpackage-input</input>
-                  <mainJar>${project.build.finalName}-thin.jar</mainJar>
-                  <mainClass>com.github.javydreamercsw.Application</mainClass>
+                  <mainJar>atw-launcher-${project.version}.jar</mainJar>
+                  <mainClass>com.github.javydreamercsw.Launcher</mainClass>
                   <destination>${project.build.directory}/dist</destination>
-                  <javaOptions>
-                    <option>-Dspring.profiles.active=prod</option>
-                    <option>-Djava.awt.headless=false</option>
-                    <option>-Datw.desktop.enabled=true</option>
-                    <option>-Dserver.port=0</option>
-                  </javaOptions>
                   <type>${jpackage.type}</type>
                   <icon>${jpackage.icon}</icon>
                   <!-- Platform specific configurations -->
@@ -1541,6 +1535,60 @@
           <artifactId>spring-boot-starter-jetty</artifactId>
         </dependency>
       </dependencies>
+    </profile>
+    <profile>
+      <!-- Builds the tiny standalone launcher JAR used by desktop installers. -->
+      <!-- Activate alongside the desktop profile: -Pproduction,desktop,launcher -->
+      <id>launcher</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.6.1</version>
+            <executions>
+              <execution>
+                <id>add-launcher-source</id>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <sources>
+                    <source>src/launcher/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>launcher-jar</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <classifier>launcher</classifier>
+                  <finalName>atw-launcher-${project.version}</finalName>
+                  <includes>
+                    <include>com/github/javydreamercsw/Launcher.class</include>
+                  </includes>
+                  <archive>
+                    <manifest>
+                      <mainClass>com.github.javydreamercsw.Launcher</mainClass>
+                    </manifest>
+                  </archive>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>war</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1461,7 +1461,7 @@
                 <configuration>
                   <target>
                     <mkdir dir="${project.build.directory}/jpackage-input"/>
-                    <copy file="${project.build.directory}/atw-launcher-${project.version}.jar" tofile="${project.build.directory}/jpackage-input/atw-launcher-${project.version}.jar"/>
+                    <copy file="${project.build.directory}/${project.artifactId}-${project.version}-launcher.jar" tofile="${project.build.directory}/jpackage-input/atw-launcher-${project.version}.jar"/>
                   </target>
                 </configuration>
               </execution>
@@ -1543,25 +1543,6 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>build-helper-maven-plugin</artifactId>
-            <version>3.6.1</version>
-            <executions>
-              <execution>
-                <id>add-launcher-source</id>
-                <goals>
-                  <goal>add-source</goal>
-                </goals>
-                <phase>generate-sources</phase>
-                <configuration>
-                  <sources>
-                    <source>src/launcher/java</source>
-                  </sources>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
             <executions>
@@ -1570,10 +1551,9 @@
                 <goals>
                   <goal>jar</goal>
                 </goals>
-                <phase>package</phase>
+                <phase>prepare-package</phase>
                 <configuration>
                   <classifier>launcher</classifier>
-                  <finalName>atw-launcher-${project.version}</finalName>
                   <includes>
                     <include>com/github/javydreamercsw/Launcher.class</include>
                   </includes>
@@ -1582,7 +1562,6 @@
                       <mainClass>com.github.javydreamercsw.Launcher</mainClass>
                     </manifest>
                   </archive>
-                  <outputDirectory>${project.build.directory}</outputDirectory>
                 </configuration>
               </execution>
             </executions>

--- a/scripts/portable/start-linux.sh
+++ b/scripts/portable/start-linux.sh
@@ -1,8 +1,97 @@
 #!/bin/bash
-JAR_FILE=$(ls all-time-wrestling-rpg-*.jar | head -n 1)
-echo "Starting All Time Wrestling RPG..."
-java -jar "$JAR_FILE" --atw.desktop.enabled=true --spring.profiles.active=prod,h2
-if [ $? -ne 0 ]; then
-    echo "An error occurred. Press any key to exit."
-    read -n 1
+set -euo pipefail
+
+REPO="javydreamercsw/all-time-wrestling-rpg"
+API_URL="https://api.github.com/repos/${REPO}/releases/latest"
+
+jar_version() {
+  echo "$1" | sed 's/all-time-wrestling-rpg-\([^.][^.]*\.[^.]*\.[^.]*\)\.jar/\1/'
+}
+
+is_newer() {
+  [ "$(printf '%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ] && [ "$1" != "$2" ]
+}
+
+check_and_update() {
+  CURRENT_JAR=$(ls all-time-wrestling-rpg-*.jar 2>/dev/null | head -n 1)
+  CURRENT_VER=""
+  if [ -n "$CURRENT_JAR" ]; then
+    CURRENT_VER=$(jar_version "$CURRENT_JAR")
+  fi
+
+  echo "Checking for updates..."
+  LATEST_JSON=$(curl -sf --max-time 15 "$API_URL" || true)
+  if [ -z "$LATEST_JSON" ]; then
+    echo "Could not reach GitHub — launching existing version."
+    return
+  fi
+
+  LATEST_TAG=$(echo "$LATEST_JSON" | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/')
+  ASSET_URL=$(echo "$LATEST_JSON" | grep '"browser_download_url"' | grep '\.jar"' | grep -v '\.war"' | head -n 1 | sed 's/.*"\(https[^"]*\)".*/\1/')
+
+  if [ -z "$LATEST_TAG" ] || [ -z "$ASSET_URL" ]; then
+    echo "Could not parse release info — launching existing version."
+    return
+  fi
+
+  if [ -z "$CURRENT_JAR" ] || is_newer "$LATEST_TAG" "$CURRENT_VER"; then
+    if [ -n "$CURRENT_JAR" ]; then
+      read -r -p "Update v${LATEST_TAG} available. Apply now? [y/N] " REPLY
+      if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
+        return
+      fi
+    else
+      echo "No application JAR found. Downloading v${LATEST_TAG}..."
+    fi
+
+    TMP_JAR="all-time-wrestling-rpg-${LATEST_TAG}.jar.tmp"
+    NEW_JAR="all-time-wrestling-rpg-${LATEST_TAG}.jar"
+
+    echo "Downloading v${LATEST_TAG}..."
+    if curl -L --max-time 600 -o "$TMP_JAR" "$ASSET_URL"; then
+      if unzip -t "$TMP_JAR" >/dev/null 2>&1; then
+        [ -n "$CURRENT_JAR" ] && mv "$CURRENT_JAR" "${CURRENT_JAR}.old"
+        mv "$TMP_JAR" "$NEW_JAR"
+        CURRENT_JAR="$NEW_JAR"
+        echo "Update applied: v${LATEST_TAG}"
+      else
+        echo "Downloaded file is corrupt — keeping existing version."
+        rm -f "$TMP_JAR"
+      fi
+    else
+      echo "Download failed — launching existing version."
+      rm -f "$TMP_JAR"
+    fi
+  else
+    echo "Already up to date (v${CURRENT_VER})."
+  fi
+}
+
+find . -maxdepth 1 -name "*.jar.tmp" -mmin +60 -delete 2>/dev/null || true
+
+check_and_update
+
+JAR_FILE=$(ls all-time-wrestling-rpg-*.jar 2>/dev/null | head -n 1)
+if [ -z "$JAR_FILE" ]; then
+  echo "No application JAR found. Exiting."
+  exit 1
 fi
+
+echo "Starting All Time Wrestling RPG (${JAR_FILE})..."
+java -jar "$JAR_FILE" --spring.profiles.active=prod,h2
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+  BACKUP=$(ls ./*.jar.old 2>/dev/null | head -n 1)
+  if [ -n "$BACKUP" ]; then
+    echo "Application crashed (exit $EXIT_CODE). Restoring previous version..."
+    RESTORED="${BACKUP%.old}"
+    mv "$BACKUP" "$RESTORED"
+    rm -f "$JAR_FILE"
+    echo "Restored. Please try launching again."
+  fi
+  read -n 1 -s -r -p "Press any key to exit."
+  echo
+fi
+
+exit $EXIT_CODE

--- a/scripts/portable/start-macos.sh
+++ b/scripts/portable/start-macos.sh
@@ -1,8 +1,102 @@
 #!/bin/bash
-JAR_FILE=$(ls all-time-wrestling-rpg-*.jar | head -n 1)
-echo "Starting All Time Wrestling RPG..."
-java -jar "$JAR_FILE" --atw.desktop.enabled=true --spring.profiles.active=prod,h2
-if [ $? -ne 0 ]; then
-    echo "An error occurred. Press any key to exit."
-    read -n 1
+set -euo pipefail
+
+REPO="javydreamercsw/all-time-wrestling-rpg"
+API_URL="https://api.github.com/repos/${REPO}/releases/latest"
+
+# Extract the version from a JAR filename (all-time-wrestling-rpg-2.5.0.jar → 2.5.0)
+jar_version() {
+  echo "$1" | sed 's/all-time-wrestling-rpg-\([^.][^.]*\.[^.]*\.[^.]*\)\.jar/\1/'
+}
+
+# Returns 0 if $1 > $2 (semver), 1 otherwise
+is_newer() {
+  [ "$(printf '%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ] && [ "$1" != "$2" ]
+}
+
+check_and_update() {
+  CURRENT_JAR=$(ls all-time-wrestling-rpg-*.jar 2>/dev/null | head -n 1)
+  CURRENT_VER=""
+  if [ -n "$CURRENT_JAR" ]; then
+    CURRENT_VER=$(jar_version "$CURRENT_JAR")
+  fi
+
+  echo "Checking for updates..."
+  LATEST_JSON=$(curl -sf --max-time 15 "$API_URL" || true)
+  if [ -z "$LATEST_JSON" ]; then
+    echo "Could not reach GitHub — launching existing version."
+    return
+  fi
+
+  LATEST_TAG=$(echo "$LATEST_JSON" | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/')
+  ASSET_URL=$(echo "$LATEST_JSON" | grep '"browser_download_url"' | grep '\.jar"' | grep -v '\.war"' | head -n 1 | sed 's/.*"\(https[^"]*\)".*/\1/')
+
+  if [ -z "$LATEST_TAG" ] || [ -z "$ASSET_URL" ]; then
+    echo "Could not parse release info — launching existing version."
+    return
+  fi
+
+  if [ -z "$CURRENT_JAR" ] || is_newer "$LATEST_TAG" "$CURRENT_VER"; then
+    if [ -n "$CURRENT_JAR" ]; then
+      read -r -p "Update v${LATEST_TAG} available. Apply now? [y/N] " REPLY
+      if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
+        return
+      fi
+    else
+      echo "No application JAR found. Downloading v${LATEST_TAG}..."
+    fi
+
+    TMP_JAR="all-time-wrestling-rpg-${LATEST_TAG}.jar.tmp"
+    NEW_JAR="all-time-wrestling-rpg-${LATEST_TAG}.jar"
+
+    echo "Downloading v${LATEST_TAG}..."
+    if curl -L --max-time 600 -o "$TMP_JAR" "$ASSET_URL"; then
+      # Validate: must be a valid ZIP
+      if unzip -t "$TMP_JAR" >/dev/null 2>&1; then
+        [ -n "$CURRENT_JAR" ] && mv "$CURRENT_JAR" "${CURRENT_JAR}.old"
+        mv "$TMP_JAR" "$NEW_JAR"
+        CURRENT_JAR="$NEW_JAR"
+        echo "Update applied: v${LATEST_TAG}"
+      else
+        echo "Downloaded file is corrupt — keeping existing version."
+        rm -f "$TMP_JAR"
+      fi
+    else
+      echo "Download failed — launching existing version."
+      rm -f "$TMP_JAR"
+    fi
+  else
+    echo "Already up to date (v${CURRENT_VER})."
+  fi
+}
+
+# Clean up stale .tmp files older than 1 hour
+find . -maxdepth 1 -name "*.jar.tmp" -mmin +60 -delete 2>/dev/null || true
+
+check_and_update
+
+JAR_FILE=$(ls all-time-wrestling-rpg-*.jar 2>/dev/null | head -n 1)
+if [ -z "$JAR_FILE" ]; then
+  echo "No application JAR found. Exiting."
+  exit 1
 fi
+
+echo "Starting All Time Wrestling RPG (${JAR_FILE})..."
+java -jar "$JAR_FILE" --atw.desktop.enabled=true --spring.profiles.active=prod,h2
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+  # Attempt to restore backup if launch failed
+  BACKUP=$(ls ./*.jar.old 2>/dev/null | head -n 1)
+  if [ -n "$BACKUP" ]; then
+    echo "Application crashed (exit $EXIT_CODE). Restoring previous version..."
+    RESTORED="${BACKUP%.old}"
+    mv "$BACKUP" "$RESTORED"
+    rm -f "$JAR_FILE"
+    echo "Restored. Please try launching again."
+  fi
+  read -n 1 -s -r -p "Press any key to exit."
+  echo
+fi
+
+exit $EXIT_CODE

--- a/scripts/portable/start-windows.bat
+++ b/scripts/portable/start-windows.bat
@@ -1,7 +1,118 @@
 @echo off
-setlocal
-for %%f in (all-time-wrestling-rpg-*.jar) do set JAR_FILE=%%f
-echo Starting All Time Wrestling RPG...
-java -jar %JAR_FILE% --atw.desktop.enabled=true --spring.profiles.active=prod,h2
-if %ERRORLEVEL% neq 0 pause
+setlocal EnableDelayedExpansion
+
+set "REPO=javydreamercsw/all-time-wrestling-rpg"
+set "API_URL=https://api.github.com/repos/%REPO%/releases/latest"
+
+:: ── Clean stale .tmp files older than 1 hour ─────────────────────────────
+for %%f in (*.jar.tmp) do (
+  forfiles /m "%%f" /d -0 /c "cmd /c del @file" 2>nul
+)
+
+:: ── Find current JAR ──────────────────────────────────────────────────────
+set "CURRENT_JAR="
+set "CURRENT_VER=0.0.0"
+for %%f in (all-time-wrestling-rpg-*.jar) do (
+  set "CURRENT_JAR=%%f"
+  set "CURRENT_VER=%%~nf"
+  :: Strip prefix to get just the version number
+  set "CURRENT_VER=!CURRENT_VER:all-time-wrestling-rpg-=!"
+)
+
+:: ── Fetch latest release info via PowerShell ──────────────────────────────
+echo Checking for updates...
+for /f "delims=" %%i in ('powershell -NoProfile -Command "try { $r = Invoke-RestMethod -Uri '%API_URL%' -TimeoutSec 15 -ErrorAction Stop; Write-Output ($r.tag_name.TrimStart('v') + '|' + ($r.assets | Where-Object { $_.name -like '*.jar' -and $_.name -notlike '*.war' } | Select-Object -First 1 -ExpandProperty browser_download_url)) } catch { Write-Output 'ERROR' }" 2^>nul') do set "RELEASE_INFO=%%i"
+
+if "%RELEASE_INFO%"=="" set "RELEASE_INFO=ERROR"
+if "%RELEASE_INFO%"=="ERROR" (
+  echo Could not reach GitHub -- launching existing version.
+  goto :launch
+)
+
+for /f "tokens=1,2 delims=|" %%a in ("%RELEASE_INFO%") do (
+  set "LATEST_VER=%%a"
+  set "ASSET_URL=%%b"
+)
+
+if "%LATEST_VER%"=="" goto :launch
+if "%ASSET_URL%"=="" goto :launch
+
+:: ── Compare versions via PowerShell ──────────────────────────────────────
+if "%CURRENT_JAR%"=="" (
+  set "NEEDS_UPDATE=1"
+) else (
+  for /f %%r in ('powershell -NoProfile -Command "([version]'%LATEST_VER%' -gt [version]'%CURRENT_VER%')"') do set "NEWER=%%r"
+  if /i "%NEWER%"=="True" (set "NEEDS_UPDATE=1") else (set "NEEDS_UPDATE=0")
+)
+
+if "%NEEDS_UPDATE%"=="0" (
+  echo Already up to date ^(v%CURRENT_VER%^).
+  goto :launch
+)
+
+:: ── Prompt user ───────────────────────────────────────────────────────────
+if not "%CURRENT_JAR%"=="" (
+  set /p "REPLY=Update v%LATEST_VER% available. Apply now? [y/N] "
+  if /i not "!REPLY!"=="y" goto :launch
+) else (
+  echo No application JAR found. Downloading v%LATEST_VER%...
+)
+
+:: ── Download with PowerShell ──────────────────────────────────────────────
+set "TMP_JAR=all-time-wrestling-rpg-%LATEST_VER%.jar.tmp"
+set "NEW_JAR=all-time-wrestling-rpg-%LATEST_VER%.jar"
+
+echo Downloading v%LATEST_VER%...
+powershell -NoProfile -Command "Invoke-WebRequest -Uri '%ASSET_URL%' -OutFile '%TMP_JAR%' -TimeoutSec 600"
+
+if errorlevel 1 (
+  echo Download failed -- launching existing version.
+  del /f /q "%TMP_JAR%" 2>nul
+  goto :launch
+)
+
+:: Validate ZIP integrity
+powershell -NoProfile -Command "Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::OpenRead('%TMP_JAR%').Dispose()"
+if errorlevel 1 (
+  echo Downloaded file is corrupt -- keeping existing version.
+  del /f /q "%TMP_JAR%" 2>nul
+  goto :launch
+)
+
+if not "%CURRENT_JAR%"=="" ren "%CURRENT_JAR%" "%CURRENT_JAR%.old"
+ren "%TMP_JAR%" "%NEW_JAR%"
+set "CURRENT_JAR=%NEW_JAR%"
+echo Update applied: v%LATEST_VER%
+
+:launch
+:: ── Find JAR to launch ────────────────────────────────────────────────────
+set "JAR_FILE="
+for %%f in (all-time-wrestling-rpg-*.jar) do set "JAR_FILE=%%f"
+
+if "%JAR_FILE%"=="" (
+  echo No application JAR found. Exiting.
+  pause
+  exit /b 1
+)
+
+echo Starting All Time Wrestling RPG ^(%JAR_FILE%^)...
+java -jar "%JAR_FILE%" --atw.desktop.enabled=true --spring.profiles.active=prod,h2
+set "EXIT_CODE=%ERRORLEVEL%"
+
+if %EXIT_CODE% neq 0 (
+  :: Attempt backup restore on crash
+  for %%f in (*.jar.old) do (
+    set "BACKUP=%%f"
+    set "RESTORED=%%~nf"
+    if not "!BACKUP!"=="" (
+      echo Application crashed ^(exit %EXIT_CODE%^). Restoring previous version...
+      ren "!BACKUP!" "!RESTORED!"
+      del /f /q "%JAR_FILE%" 2>nul
+      echo Restored. Please try launching again.
+    )
+  )
+  pause
+)
+
 endlocal
+exit /b %EXIT_CODE%

--- a/src/launcher/java/com/github/javydreamercsw/Launcher.java
+++ b/src/launcher/java/com/github/javydreamercsw/Launcher.java
@@ -1,0 +1,370 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipFile;
+import javax.swing.JOptionPane;
+
+/**
+ * Zero-dependency bootstrap launcher. Downloads or updates the full application JAR from GitHub
+ * Releases and execs it. Bundled inside the desktop installers (DMG/MSI/DEB) via jpackage so the
+ * installers themselves never need to be reinstalled when a new app version ships.
+ */
+public final class Launcher {
+
+  private static final String REPO = "javydreamercsw/all-time-wrestling-rpg";
+  private static final String RELEASES_API =
+      "https://api.github.com/repos/" + REPO + "/releases/latest";
+  private static final Pattern JAR_PATTERN =
+      Pattern.compile("all-time-wrestling-rpg-([0-9]+(?:\\.[0-9]+){0,2}(?:-[^.]+)?)\\.jar");
+  private static final Duration STALE_TMP_THRESHOLD = Duration.ofHours(1);
+
+  public static void main(final String[] args) throws Exception {
+    Path appDir = resolveAppDir();
+    Files.createDirectories(appDir);
+
+    cleanStaleTmp(appDir);
+    restoreBackupIfNeeded(appDir);
+
+    Path currentJar = findCurrentJar(appDir).orElse(null);
+    String currentVersion = currentJar == null ? null : extractVersion(currentJar.getFileName().toString());
+
+    ReleaseInfo release = fetchLatestRelease();
+
+    if (release == null) {
+      if (currentJar == null) {
+        showError("Could not connect to GitHub to download the application.\nCheck your network and try again.");
+        System.exit(1);
+      }
+      System.out.println("[Launcher] Update check failed — launching existing version " + currentVersion);
+      launchApp(currentJar, args);
+      return;
+    }
+
+    boolean needsDownload = currentJar == null || isNewer(release.version(), currentVersion);
+
+    if (needsDownload) {
+      boolean doUpdate = currentJar == null || promptUser(release.version());
+      if (doUpdate) {
+        Path newJar = download(release, appDir, currentJar);
+        if (newJar != null) {
+          currentJar = newJar;
+        }
+      }
+    }
+
+    if (currentJar == null) {
+      showError("No application JAR found. Download failed.\nCheck your network and try again.");
+      System.exit(1);
+    }
+
+    launchApp(currentJar, args);
+  }
+
+  // -------------------------------------------------------------------------
+  // App directory resolution
+  // -------------------------------------------------------------------------
+
+  private static Path resolveAppDir() {
+    String os = System.getProperty("os.name", "").toLowerCase();
+    String home = System.getProperty("user.home");
+    if (os.contains("mac")) {
+      return Path.of(home, "Library", "Application Support", "ATW");
+    } else if (os.contains("win")) {
+      String appData = System.getenv("APPDATA");
+      return Path.of(appData != null ? appData : home, "ATW");
+    } else {
+      String xdg = System.getenv("XDG_DATA_HOME");
+      return Path.of(xdg != null ? xdg : home + "/.local/share", "atw");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // JAR discovery
+  // -------------------------------------------------------------------------
+
+  private static Optional<Path> findCurrentJar(final Path dir) throws IOException {
+    if (!Files.exists(dir)) {
+      return Optional.empty();
+    }
+    return Files.list(dir)
+        .filter(p -> JAR_PATTERN.matcher(p.getFileName().toString()).matches())
+        .max(Comparator.comparing(p -> extractVersion(p.getFileName().toString())));
+  }
+
+  private static String extractVersion(final String filename) {
+    Matcher m = JAR_PATTERN.matcher(filename);
+    return m.matches() ? m.group(1) : "0.0.0";
+  }
+
+  // -------------------------------------------------------------------------
+  // GitHub release fetch
+  // -------------------------------------------------------------------------
+
+  record ReleaseInfo(String version, String jarUrl) {}
+
+  private static ReleaseInfo fetchLatestRelease() {
+    try {
+      HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+      HttpRequest req =
+          HttpRequest.newBuilder()
+              .uri(URI.create(RELEASES_API))
+              .header("Accept", "application/vnd.github+json")
+              .header("User-Agent", "all-time-wrestling-rpg-launcher")
+              .timeout(Duration.ofSeconds(15))
+              .GET()
+              .build();
+
+      HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+      if (resp.statusCode() != 200) {
+        return null;
+      }
+
+      String body = resp.body();
+      String tag = extractJsonString(body, "tag_name");
+      String version = tag != null && tag.startsWith("v") ? tag.substring(1) : tag;
+      String jarUrl = findJarAssetUrl(body);
+
+      return (version != null && jarUrl != null) ? new ReleaseInfo(version, jarUrl) : null;
+    } catch (Exception e) {
+      System.err.println("[Launcher] Could not fetch release info: " + e.getMessage());
+      return null;
+    }
+  }
+
+  private static String extractJsonString(final String json, final String key) {
+    Pattern p = Pattern.compile("\"" + key + "\"\\s*:\\s*\"([^\"]+)\"");
+    Matcher m = p.matcher(json);
+    return m.find() ? m.group(1) : null;
+  }
+
+  private static String findJarAssetUrl(final String json) {
+    // Find browser_download_url entries that end in .jar but not .war
+    Pattern p = Pattern.compile("\"browser_download_url\"\\s*:\\s*\"([^\"]+\\.jar)\"");
+    Matcher m = p.matcher(json);
+    while (m.find()) {
+      String url = m.group(1);
+      if (!url.endsWith(".war")) {
+        return url;
+      }
+    }
+    return null;
+  }
+
+  // -------------------------------------------------------------------------
+  // Version comparison
+  // -------------------------------------------------------------------------
+
+  private static boolean isNewer(final String candidate, final String current) {
+    try {
+      int[] c = semver(candidate);
+      int[] r = semver(current);
+      for (int i = 0; i < 3; i++) {
+        if (c[i] != r[i]) return c[i] > r[i];
+      }
+      return false;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static int[] semver(final String v) {
+    String numeric = v.replaceAll("[^0-9.].*$", "");
+    String[] parts = numeric.split("\\.");
+    int[] result = new int[3];
+    for (int i = 0; i < 3 && i < parts.length; i++) {
+      result[i] = parts[i].isBlank() ? 0 : Integer.parseInt(parts[i]);
+    }
+    return result;
+  }
+
+  // -------------------------------------------------------------------------
+  // Download with safe swap
+  // -------------------------------------------------------------------------
+
+  private static Path download(
+      final ReleaseInfo release, final Path appDir, final Path oldJar) {
+    Path newJarName = appDir.resolve("all-time-wrestling-rpg-" + release.version() + ".jar");
+    Path tmpPath = appDir.resolve("all-time-wrestling-rpg-" + release.version() + ".jar.tmp");
+    Path oldBackup = oldJar != null
+        ? appDir.resolve(oldJar.getFileName().toString() + ".old")
+        : null;
+
+    System.out.println("[Launcher] Downloading v" + release.version() + "...");
+    try {
+      HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(15)).build();
+      HttpRequest req =
+          HttpRequest.newBuilder()
+              .uri(URI.create(release.jarUrl()))
+              .header("User-Agent", "all-time-wrestling-rpg-launcher")
+              .timeout(Duration.ofMinutes(10))
+              .GET()
+              .build();
+
+      HttpResponse<InputStream> resp = client.send(req, HttpResponse.BodyHandlers.ofInputStream());
+      if (resp.statusCode() != 200) {
+        System.err.println("[Launcher] Download failed with HTTP " + resp.statusCode());
+        return null;
+      }
+
+      try (InputStream in = resp.body()) {
+        Files.copy(in, tmpPath, StandardCopyOption.REPLACE_EXISTING);
+      }
+
+      // Validate it's a valid ZIP/JAR before swapping
+      try (ZipFile zf = new ZipFile(tmpPath.toFile())) {
+        if (zf.size() == 0) throw new IOException("Empty ZIP");
+      } catch (IOException e) {
+        System.err.println("[Launcher] Downloaded file is corrupt — aborting update.");
+        Files.deleteIfExists(tmpPath);
+        return null;
+      }
+
+      // Safe swap: rename old → .old, then tmp → new
+      if (oldJar != null && Files.exists(oldJar)) {
+        Files.move(oldJar, oldBackup, StandardCopyOption.REPLACE_EXISTING);
+      }
+      Files.move(tmpPath, newJarName, StandardCopyOption.REPLACE_EXISTING);
+
+      System.out.println("[Launcher] Download complete: " + newJarName.getFileName());
+      return newJarName;
+
+    } catch (Exception e) {
+      System.err.println("[Launcher] Download error: " + e.getMessage());
+      try { Files.deleteIfExists(tmpPath); } catch (IOException ignored) {}
+      return null;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Launch the app JAR as a child process; wait briefly to detect a crash
+  // -------------------------------------------------------------------------
+
+  private static void launchApp(final Path jar, final String[] extraArgs) throws Exception {
+    String java = ProcessHandle.current().info().command()
+        .orElse(Path.of(System.getProperty("java.home"), "bin", "java").toString());
+
+    List<String> cmd = new ArrayList<>();
+    cmd.add(java);
+    cmd.add("-jar");
+    cmd.add(jar.toAbsolutePath().toString());
+    cmd.add("--atw.desktop.enabled=true");
+    cmd.add("--spring.profiles.active=prod,h2");
+    for (String arg : extraArgs) {
+      cmd.add(arg);
+    }
+
+    System.out.println("[Launcher] Starting " + jar.getFileName());
+    ProcessBuilder pb = new ProcessBuilder(cmd);
+    pb.inheritIO();
+    Process process = pb.start();
+
+    // Wait up to 5 s to catch an immediate crash (bad JAR, wrong Java version, etc.)
+    boolean exited = process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS);
+    if (exited && process.exitValue() != 0) {
+      System.err.println("[Launcher] Application exited immediately with code " + process.exitValue()
+          + " — restoring previous version if available.");
+      restoreBackupIfNeeded(jar.getParent());
+      showError("The application failed to start (exit code " + process.exitValue() + ").\n"
+          + "The previous version has been restored. Please try again.");
+      System.exit(process.exitValue());
+    }
+
+    // Normal case: app is running; wait for it to finish then exit with its code
+    System.exit(process.waitFor());
+  }
+
+  // -------------------------------------------------------------------------
+  // Cleanup helpers
+  // -------------------------------------------------------------------------
+
+  private static void cleanStaleTmp(final Path dir) throws IOException {
+    if (!Files.exists(dir)) return;
+    Instant cutoff = Instant.now().minus(STALE_TMP_THRESHOLD);
+    Files.list(dir)
+        .filter(p -> p.getFileName().toString().endsWith(".tmp"))
+        .filter(p -> {
+          try { return Files.getLastModifiedTime(p).toInstant().isBefore(cutoff); }
+          catch (IOException e) { return false; }
+        })
+        .forEach(p -> { try { Files.delete(p); } catch (IOException e) { /* ignore */ } });
+  }
+
+  private static void restoreBackupIfNeeded(final Path dir) throws IOException {
+    if (!Files.exists(dir)) return;
+    // If a .old backup exists but no current JAR, restore it
+    Optional<Path> backup = Files.list(dir)
+        .filter(p -> p.getFileName().toString().endsWith(".jar.old"))
+        .findFirst();
+    if (backup.isEmpty()) return;
+    Optional<Path> current = findCurrentJar(dir);
+    if (current.isEmpty()) {
+      String name = backup.get().getFileName().toString().replace(".old", "");
+      Files.move(backup.get(), dir.resolve(name), StandardCopyOption.REPLACE_EXISTING);
+      System.out.println("[Launcher] Restored backup JAR: " + name);
+    } else {
+      // Current JAR exists and appears healthy — safe to remove old backup
+      Files.deleteIfExists(backup.get());
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // UI helpers
+  // -------------------------------------------------------------------------
+
+  private static boolean promptUser(final String newVersion) {
+    if (System.console() != null) {
+      System.out.print("[Launcher] Update v" + newVersion + " available. Apply now? [y/N] ");
+      String response = System.console().readLine();
+      return response != null && response.trim().equalsIgnoreCase("y");
+    }
+    // GUI prompt for desktop installs
+    int choice = JOptionPane.showConfirmDialog(
+        null,
+        "All Time Wrestling RPG v" + newVersion + " is available.\nDownload and apply update?",
+        "Update Available",
+        JOptionPane.YES_NO_OPTION,
+        JOptionPane.INFORMATION_MESSAGE);
+    return choice == JOptionPane.YES_OPTION;
+  }
+
+  private static void showError(final String message) {
+    System.err.println("[Launcher] " + message);
+    try {
+      JOptionPane.showMessageDialog(null, message, "Launcher Error", JOptionPane.ERROR_MESSAGE);
+    } catch (Exception ignored) {}
+  }
+
+  private Launcher() {}
+}

--- a/src/main/java/com/github/javydreamercsw/Launcher.java
+++ b/src/main/java/com/github/javydreamercsw/Launcher.java
@@ -165,7 +165,7 @@ public final class Launcher {
       String version = tag != null && tag.startsWith("v") ? tag.substring(1) : tag;
       String jarUrl = findJarAssetUrl(body);
 
-      return (version != null && jarUrl != null) ? new ReleaseInfo(version, jarUrl) : null;
+      return version != null && jarUrl != null ? new ReleaseInfo(version, jarUrl) : null;
     } catch (Exception e) {
       System.err.println("[Launcher] Could not fetch release info: " + e.getMessage());
       return null;
@@ -200,7 +200,9 @@ public final class Launcher {
       int[] c = semver(candidate);
       int[] r = semver(current);
       for (int i = 0; i < 3; i++) {
-        if (c[i] != r[i]) return c[i] > r[i];
+        if (c[i] != r[i]) {
+          return c[i] > r[i];
+        }
       }
       return false;
     } catch (Exception e) {
@@ -254,7 +256,9 @@ public final class Launcher {
 
       // Validate it's a valid ZIP/JAR before swapping
       try (ZipFile zf = new ZipFile(tmpPath.toFile())) {
-        if (zf.size() == 0) throw new IOException("Empty ZIP");
+        if (zf.size() == 0) {
+          throw new IOException("Empty ZIP");
+        }
       } catch (IOException e) {
         System.err.println("[Launcher] Downloaded file is corrupt — aborting update.");
         Files.deleteIfExists(tmpPath);
@@ -331,7 +335,9 @@ public final class Launcher {
   // -------------------------------------------------------------------------
 
   private static void cleanStaleTmp(final Path dir) throws IOException {
-    if (!Files.exists(dir)) return;
+    if (!Files.exists(dir)) {
+      return;
+    }
     Instant cutoff = Instant.now().minus(STALE_TMP_THRESHOLD);
     Files.list(dir)
         .filter(p -> p.getFileName().toString().endsWith(".tmp"))
@@ -354,11 +360,15 @@ public final class Launcher {
   }
 
   private static void restoreBackupIfNeeded(final Path dir) throws IOException {
-    if (!Files.exists(dir)) return;
+    if (!Files.exists(dir)) {
+      return;
+    }
     // If a .old backup exists but no current JAR, restore it
     Optional<Path> backup =
         Files.list(dir).filter(p -> p.getFileName().toString().endsWith(".jar.old")).findFirst();
-    if (backup.isEmpty()) return;
+    if (backup.isEmpty()) {
+      return;
+    }
     Optional<Path> current = findCurrentJar(dir);
     if (current.isEmpty()) {
       String name = backup.get().getFileName().toString().replace(".old", "");

--- a/src/main/java/com/github/javydreamercsw/Launcher.java
+++ b/src/main/java/com/github/javydreamercsw/Launcher.java
@@ -138,12 +138,17 @@ public final class Launcher {
 
   record ReleaseInfo(String version, String jarUrl) {}
 
-  private static ReleaseInfo fetchLatestRelease() {
+  private static String releasesApiUrl() {
+    String override = System.getProperty("atw.launcher.releases-api");
+    return override != null ? override : RELEASES_API;
+  }
+
+  static ReleaseInfo fetchLatestRelease() {
     try {
       HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
       HttpRequest req =
           HttpRequest.newBuilder()
-              .uri(URI.create(RELEASES_API))
+              .uri(URI.create(releasesApiUrl()))
               .header("Accept", "application/vnd.github+json")
               .header("User-Agent", "all-time-wrestling-rpg-launcher")
               .timeout(Duration.ofSeconds(15))
@@ -190,7 +195,7 @@ public final class Launcher {
   // Version comparison
   // -------------------------------------------------------------------------
 
-  private static boolean isNewer(final String candidate, final String current) {
+  static boolean isNewer(final String candidate, final String current) {
     try {
       int[] c = semver(candidate);
       int[] r = semver(current);
@@ -203,8 +208,11 @@ public final class Launcher {
     }
   }
 
-  private static int[] semver(final String v) {
+  static int[] semver(final String v) {
     String numeric = v.replaceAll("[^0-9.].*$", "");
+    if (numeric.isBlank()) {
+      throw new IllegalArgumentException("Unparseable version: " + v);
+    }
     String[] parts = numeric.split("\\.");
     int[] result = new int[3];
     for (int i = 0; i < 3 && i < parts.length; i++) {
@@ -217,7 +225,7 @@ public final class Launcher {
   // Download with safe swap
   // -------------------------------------------------------------------------
 
-  private static Path download(final ReleaseInfo release, final Path appDir, final Path oldJar) {
+  static Path download(final ReleaseInfo release, final Path appDir, final Path oldJar) {
     Path newJarName = appDir.resolve("all-time-wrestling-rpg-" + release.version() + ".jar");
     Path tmpPath = appDir.resolve("all-time-wrestling-rpg-" + release.version() + ".jar.tmp");
     Path oldBackup =

--- a/src/main/java/com/github/javydreamercsw/Launcher.java
+++ b/src/main/java/com/github/javydreamercsw/Launcher.java
@@ -58,16 +58,20 @@ public final class Launcher {
     restoreBackupIfNeeded(appDir);
 
     Path currentJar = findCurrentJar(appDir).orElse(null);
-    String currentVersion = currentJar == null ? null : extractVersion(currentJar.getFileName().toString());
+    String currentVersion =
+        currentJar == null ? null : extractVersion(currentJar.getFileName().toString());
 
     ReleaseInfo release = fetchLatestRelease();
 
     if (release == null) {
       if (currentJar == null) {
-        showError("Could not connect to GitHub to download the application.\nCheck your network and try again.");
+        showError(
+            "Could not connect to GitHub to download the application.\n"
+                + "Check your network and try again.");
         System.exit(1);
       }
-      System.out.println("[Launcher] Update check failed — launching existing version " + currentVersion);
+      System.out.println(
+          "[Launcher] Update check failed — launching existing version " + currentVersion);
       launchApp(currentJar, args);
       return;
     }
@@ -213,13 +217,11 @@ public final class Launcher {
   // Download with safe swap
   // -------------------------------------------------------------------------
 
-  private static Path download(
-      final ReleaseInfo release, final Path appDir, final Path oldJar) {
+  private static Path download(final ReleaseInfo release, final Path appDir, final Path oldJar) {
     Path newJarName = appDir.resolve("all-time-wrestling-rpg-" + release.version() + ".jar");
     Path tmpPath = appDir.resolve("all-time-wrestling-rpg-" + release.version() + ".jar.tmp");
-    Path oldBackup = oldJar != null
-        ? appDir.resolve(oldJar.getFileName().toString() + ".old")
-        : null;
+    Path oldBackup =
+        oldJar != null ? appDir.resolve(oldJar.getFileName().toString() + ".old") : null;
 
     System.out.println("[Launcher] Downloading v" + release.version() + "...");
     try {
@@ -262,7 +264,10 @@ public final class Launcher {
 
     } catch (Exception e) {
       System.err.println("[Launcher] Download error: " + e.getMessage());
-      try { Files.deleteIfExists(tmpPath); } catch (IOException ignored) {}
+      try {
+        Files.deleteIfExists(tmpPath);
+      } catch (IOException ignored) {
+      }
       return null;
     }
   }
@@ -272,11 +277,14 @@ public final class Launcher {
   // -------------------------------------------------------------------------
 
   private static void launchApp(final Path jar, final String[] extraArgs) throws Exception {
-    String java = ProcessHandle.current().info().command()
-        .orElse(Path.of(System.getProperty("java.home"), "bin", "java").toString());
+    String javaExe =
+        ProcessHandle.current()
+            .info()
+            .command()
+            .orElse(Path.of(System.getProperty("java.home"), "bin", "java").toString());
 
     List<String> cmd = new ArrayList<>();
-    cmd.add(java);
+    cmd.add(javaExe);
     cmd.add("-jar");
     cmd.add(jar.toAbsolutePath().toString());
     cmd.add("--atw.desktop.enabled=true");
@@ -293,11 +301,16 @@ public final class Launcher {
     // Wait up to 5 s to catch an immediate crash (bad JAR, wrong Java version, etc.)
     boolean exited = process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS);
     if (exited && process.exitValue() != 0) {
-      System.err.println("[Launcher] Application exited immediately with code " + process.exitValue()
-          + " — restoring previous version if available.");
+      System.err.println(
+          "[Launcher] Application exited immediately with code "
+              + process.exitValue()
+              + " — restoring previous version if available.");
       restoreBackupIfNeeded(jar.getParent());
-      showError("The application failed to start (exit code " + process.exitValue() + ").\n"
-          + "The previous version has been restored. Please try again.");
+      showError(
+          "The application failed to start (exit code "
+              + process.exitValue()
+              + ").\n"
+              + "The previous version has been restored. Please try again.");
       System.exit(process.exitValue());
     }
 
@@ -314,19 +327,29 @@ public final class Launcher {
     Instant cutoff = Instant.now().minus(STALE_TMP_THRESHOLD);
     Files.list(dir)
         .filter(p -> p.getFileName().toString().endsWith(".tmp"))
-        .filter(p -> {
-          try { return Files.getLastModifiedTime(p).toInstant().isBefore(cutoff); }
-          catch (IOException e) { return false; }
-        })
-        .forEach(p -> { try { Files.delete(p); } catch (IOException e) { /* ignore */ } });
+        .filter(
+            p -> {
+              try {
+                return Files.getLastModifiedTime(p).toInstant().isBefore(cutoff);
+              } catch (IOException e) {
+                return false;
+              }
+            })
+        .forEach(
+            p -> {
+              try {
+                Files.delete(p);
+              } catch (IOException e) {
+                /* ignore */
+              }
+            });
   }
 
   private static void restoreBackupIfNeeded(final Path dir) throws IOException {
     if (!Files.exists(dir)) return;
     // If a .old backup exists but no current JAR, restore it
-    Optional<Path> backup = Files.list(dir)
-        .filter(p -> p.getFileName().toString().endsWith(".jar.old"))
-        .findFirst();
+    Optional<Path> backup =
+        Files.list(dir).filter(p -> p.getFileName().toString().endsWith(".jar.old")).findFirst();
     if (backup.isEmpty()) return;
     Optional<Path> current = findCurrentJar(dir);
     if (current.isEmpty()) {
@@ -350,12 +373,13 @@ public final class Launcher {
       return response != null && response.trim().equalsIgnoreCase("y");
     }
     // GUI prompt for desktop installs
-    int choice = JOptionPane.showConfirmDialog(
-        null,
-        "All Time Wrestling RPG v" + newVersion + " is available.\nDownload and apply update?",
-        "Update Available",
-        JOptionPane.YES_NO_OPTION,
-        JOptionPane.INFORMATION_MESSAGE);
+    int choice =
+        JOptionPane.showConfirmDialog(
+            null,
+            "All Time Wrestling RPG v" + newVersion + " is available.\nDownload and apply update?",
+            "Update Available",
+            JOptionPane.YES_NO_OPTION,
+            JOptionPane.INFORMATION_MESSAGE);
     return choice == JOptionPane.YES_OPTION;
   }
 
@@ -363,7 +387,8 @@ public final class Launcher {
     System.err.println("[Launcher] " + message);
     try {
       JOptionPane.showMessageDialog(null, message, "Launcher Error", JOptionPane.ERROR_MESSAGE);
-    } catch (Exception ignored) {}
+    } catch (Exception ignored) {
+    }
   }
 
   private Launcher() {}

--- a/src/main/java/com/github/javydreamercsw/base/config/DesktopIntegration.java
+++ b/src/main/java/com/github/javydreamercsw/base/config/DesktopIntegration.java
@@ -16,6 +16,7 @@
 */
 package com.github.javydreamercsw.base.config;
 
+import com.github.javydreamercsw.base.event.UpdateAvailableEvent;
 import jakarta.servlet.ServletContext;
 import java.awt.AWTException;
 import java.awt.Desktop;
@@ -37,6 +38,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.web.server.servlet.context.ServletWebServerApplicationContext;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.EventListener;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
@@ -58,6 +60,9 @@ public class DesktopIntegration implements ApplicationListener<ApplicationReadyE
 
   @Value("${server.port:8080}")
   private int defaultPort;
+
+  private TrayIcon trayIcon;
+  private PopupMenu trayPopup;
 
   @Override
   public void onApplicationEvent(final ApplicationReadyEvent event) {
@@ -149,18 +154,18 @@ public class DesktopIntegration implements ApplicationListener<ApplicationReadyE
     try {
       SystemTray tray = SystemTray.getSystemTray();
 
-      PopupMenu popup = new PopupMenu();
+      trayPopup = new PopupMenu();
       MenuItem openItem = new MenuItem("Open Game");
       openItem.addActionListener(e -> launchBrowser(url));
-      popup.add(openItem);
+      trayPopup.add(openItem);
 
-      popup.addSeparator();
+      trayPopup.addSeparator();
 
       MenuItem exitItem = new MenuItem("Exit");
       exitItem.addActionListener(e -> System.exit(0));
-      popup.add(exitItem);
+      trayPopup.add(exitItem);
 
-      TrayIcon trayIcon = new TrayIcon(image, "All Time Wrestling RPG", popup);
+      trayIcon = new TrayIcon(image, "All Time Wrestling RPG", trayPopup);
       trayIcon.setImageAutoSize(true);
       trayIcon.addActionListener(e -> launchBrowser(url));
 
@@ -170,5 +175,25 @@ public class DesktopIntegration implements ApplicationListener<ApplicationReadyE
     } catch (AWTException e) {
       log.error("Failed to setup System Tray", e);
     }
+  }
+
+  @EventListener
+  public void onUpdateAvailable(final UpdateAvailableEvent event) {
+    if (trayIcon == null || trayPopup == null) {
+      return;
+    }
+
+    String label = "Update available: v" + event.getNewVersion();
+
+    MenuItem updateItem = new MenuItem(label);
+    updateItem.addActionListener(e -> launchBrowser(event.getReleaseUrl()));
+
+    // Insert before the Exit separator (second-to-last item)
+    trayPopup.insert(updateItem, trayPopup.getItemCount() - 2);
+
+    trayIcon.displayMessage(
+        "Update Available",
+        "All Time Wrestling RPG v" + event.getNewVersion() + " is ready to download.",
+        TrayIcon.MessageType.INFO);
   }
 }

--- a/src/main/java/com/github/javydreamercsw/base/domain/account/AccountRepository.java
+++ b/src/main/java/com/github/javydreamercsw/base/domain/account/AccountRepository.java
@@ -16,6 +16,7 @@
 */
 package com.github.javydreamercsw.base.domain.account;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -44,5 +45,7 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
   @Query(
       "SELECT a FROM Account a WHERE a.id NOT IN "
           + "(SELECT DISTINCT w.account.id FROM Wrestler w WHERE w.account IS NOT NULL)")
-  java.util.List<Account> findAccountsWithNoAssignedWrestler();
+  List<Account> findAccountsWithNoAssignedWrestler();
+
+  List<Account> findAllByRoles_Name(RoleName roleName);
 }

--- a/src/main/java/com/github/javydreamercsw/base/event/UpdateAvailableEvent.java
+++ b/src/main/java/com/github/javydreamercsw/base/event/UpdateAvailableEvent.java
@@ -1,0 +1,34 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.base.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class UpdateAvailableEvent extends ApplicationEvent {
+
+  private final String newVersion;
+  private final String releaseUrl;
+
+  public UpdateAvailableEvent(
+      final Object source, final String newVersion, final String releaseUrl) {
+    super(source);
+    this.newVersion = newVersion;
+    this.releaseUrl = releaseUrl;
+  }
+}

--- a/src/main/java/com/github/javydreamercsw/base/service/UpdateCheckService.java
+++ b/src/main/java/com/github/javydreamercsw/base/service/UpdateCheckService.java
@@ -1,0 +1,128 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.base.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javydreamercsw.base.event.UpdateAvailableEvent;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnProperty(name = "atw.update-check.enabled", matchIfMissing = true)
+@RequiredArgsConstructor
+@Slf4j
+public class UpdateCheckService {
+
+  private static final String RELEASES_API =
+      "https://api.github.com/repos/javydreamercsw/all-time-wrestling-rpg/releases/latest";
+
+  private final ApplicationEventPublisher eventPublisher;
+  private final ObjectMapper objectMapper;
+  private final Optional<BuildProperties> buildProperties;
+
+  @EventListener(ApplicationReadyEvent.class)
+  @Async
+  public void checkForUpdates() {
+    try {
+      String currentVersion = buildProperties.map(BuildProperties::getVersion).orElse(null);
+      if (currentVersion == null || currentVersion.endsWith("-SNAPSHOT")) {
+        log.debug("Skipping update check for SNAPSHOT build.");
+        return;
+      }
+
+      HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(RELEASES_API))
+              .header("Accept", "application/vnd.github+json")
+              .header("User-Agent", "all-time-wrestling-rpg/" + currentVersion)
+              .timeout(Duration.ofSeconds(15))
+              .GET()
+              .build();
+
+      HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+      if (response.statusCode() != 200) {
+        log.warn("Update check returned HTTP {}", response.statusCode());
+        return;
+      }
+
+      JsonNode json = objectMapper.readTree(response.body());
+      String tagName = json.path("tag_name").asText("");
+      String htmlUrl = json.path("html_url").asText("");
+
+      if (tagName.isBlank()) {
+        return;
+      }
+
+      String latestVersion = tagName.startsWith("v") ? tagName.substring(1) : tagName;
+
+      if (isNewer(latestVersion, currentVersion)) {
+        log.info("Update available: {} (current: {})", latestVersion, currentVersion);
+        eventPublisher.publishEvent(new UpdateAvailableEvent(this, latestVersion, htmlUrl));
+      } else {
+        log.debug("Application is up to date ({})", currentVersion);
+      }
+    } catch (Exception e) {
+      log.warn("Update check failed: {}", e.getMessage());
+    }
+  }
+
+  /** Returns true if {@code candidate} is strictly newer than {@code current} using semver. */
+  static boolean isNewer(final String candidate, final String current) {
+    try {
+      int[] c = parseSemver(candidate);
+      int[] r = parseSemver(current);
+      for (int i = 0; i < 3; i++) {
+        if (c[i] != r[i]) {
+          return c[i] > r[i];
+        }
+      }
+      return false;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static int[] parseSemver(final String version) {
+    // Strip any pre-release suffix (e.g. "2.5.0-RC1" → [2, 5, 0])
+    String numeric = version.replaceAll("[^0-9.].*$", "").replaceAll("^\\.+|\\.+$", "");
+    if (numeric.isBlank()) {
+      throw new IllegalArgumentException("Unparseable version: " + version);
+    }
+    String[] parts = numeric.split("\\.");
+    int[] result = new int[3];
+    for (int i = 0; i < 3 && i < parts.length; i++) {
+      result[i] = parts[i].isBlank() ? 0 : Integer.parseInt(parts[i]);
+    }
+    return result;
+  }
+}

--- a/src/main/java/com/github/javydreamercsw/management/config/InboxEventTypeConfig.java
+++ b/src/main/java/com/github/javydreamercsw/management/config/InboxEventTypeConfig.java
@@ -130,4 +130,9 @@ public class InboxEventTypeConfig {
   @Qualifier("TUTORIAL_REMINDER") InboxEventType tutorialReminder() {
     return new InboxEventType("TUTORIAL_REMINDER", "Tutorial Reminder");
   }
+
+  @Bean
+  @Qualifier("UPDATE_AVAILABLE") InboxEventType updateAvailable() {
+    return new InboxEventType("UPDATE_AVAILABLE", "Update Available");
+  }
 }

--- a/src/main/java/com/github/javydreamercsw/management/event/inbox/UpdateAvailableInboxListener.java
+++ b/src/main/java/com/github/javydreamercsw/management/event/inbox/UpdateAvailableInboxListener.java
@@ -1,0 +1,84 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.event.inbox;
+
+import com.github.javydreamercsw.base.domain.account.AccountRepository;
+import com.github.javydreamercsw.base.domain.account.RoleName;
+import com.github.javydreamercsw.base.event.UpdateAvailableEvent;
+import com.github.javydreamercsw.base.security.GeneralSecurityUtils;
+import com.github.javydreamercsw.management.domain.inbox.InboxEventType;
+import com.github.javydreamercsw.management.domain.inbox.InboxItem;
+import com.github.javydreamercsw.management.domain.inbox.InboxItemTarget;
+import com.github.javydreamercsw.management.service.inbox.InboxService;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class UpdateAvailableInboxListener implements ApplicationListener<UpdateAvailableEvent> {
+
+  private final InboxService inboxService;
+
+  @Qualifier("UPDATE_AVAILABLE") private final InboxEventType updateAvailableEventType;
+
+  private final AccountRepository accountRepository;
+  private final InboxUpdateBroadcaster inboxUpdateBroadcaster;
+
+  @Override
+  public void onApplicationEvent(@NonNull final UpdateAvailableEvent event) {
+    String message =
+        "A new version of All Time Wrestling RPG is available: v%s. Visit %s to download."
+            .formatted(event.getNewVersion(), event.getReleaseUrl());
+
+    List<InboxService.TargetInfo> adminTargets =
+        GeneralSecurityUtils.runAsAdmin(
+            () ->
+                accountRepository.findAllByRoles_Name(RoleName.ADMIN).stream()
+                    .filter(a -> a.getId() != null)
+                    .map(
+                        a ->
+                            new InboxService.TargetInfo(
+                                a.getId().toString(), InboxItemTarget.TargetType.ACCOUNT))
+                    .toList());
+
+    if (adminTargets.isEmpty()) {
+      log.warn("No ADMIN accounts found to notify about update v{}", event.getNewVersion());
+      return;
+    }
+
+    GeneralSecurityUtils.runAsAdmin(
+        () ->
+            inboxService.createInboxItem(
+                updateAvailableEventType,
+                "Update Available: v" + event.getNewVersion(),
+                message,
+                InboxItem.Urgency.INFO,
+                adminTargets));
+
+    inboxUpdateBroadcaster.broadcast(new InboxUpdateEvent(this));
+    log.info(
+        "Update available notification sent to {} admin(s) for v{}",
+        adminTargets.size(),
+        event.getNewVersion());
+  }
+}

--- a/src/main/java/com/github/javydreamercsw/management/event/inbox/UpdateAvailableInboxListener.java
+++ b/src/main/java/com/github/javydreamercsw/management/event/inbox/UpdateAvailableInboxListener.java
@@ -26,7 +26,6 @@ import com.github.javydreamercsw.management.domain.inbox.InboxItemTarget;
 import com.github.javydreamercsw.management.service.inbox.InboxService;
 import java.util.List;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationListener;
@@ -34,15 +33,23 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-@RequiredArgsConstructor
 public class UpdateAvailableInboxListener implements ApplicationListener<UpdateAvailableEvent> {
 
   private final InboxService inboxService;
-
-  @Qualifier("UPDATE_AVAILABLE") private final InboxEventType updateAvailableEventType;
-
+  private final InboxEventType updateAvailableEventType;
   private final AccountRepository accountRepository;
   private final InboxUpdateBroadcaster inboxUpdateBroadcaster;
+
+  public UpdateAvailableInboxListener(
+      @NonNull final InboxService inboxService,
+      @NonNull @Qualifier("updateAvailable") final InboxEventType updateAvailableEventType,
+      @NonNull final AccountRepository accountRepository,
+      @NonNull final InboxUpdateBroadcaster inboxUpdateBroadcaster) {
+    this.inboxService = inboxService;
+    this.updateAvailableEventType = updateAvailableEventType;
+    this.accountRepository = accountRepository;
+    this.inboxUpdateBroadcaster = inboxUpdateBroadcaster;
+  }
 
   @Override
   public void onApplicationEvent(@NonNull final UpdateAvailableEvent event) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,3 +28,6 @@ drama.events.retention.unprocessed.days=180
 # Security — remember-me token. Override via env-var SECURITY_REMEMBER_ME_KEY in production.
 security.remember-me.key=atwrpg-remember-me-key
 security.remember-me.token-validity-seconds=604800
+
+# Auto-update check on startup (disable for air-gapped installs)
+atw.update-check.enabled=true

--- a/src/test/java/com/github/javydreamercsw/LauncherTest.java
+++ b/src/test/java/com/github/javydreamercsw/LauncherTest.java
@@ -1,0 +1,232 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LauncherTest {
+
+  // ── version comparison ────────────────────────────────────────────────────
+
+  @Test
+  void isNewer_returnsTrueWhenCandidateHasHigherMinor() {
+    assertThat(Launcher.isNewer("2.6.0", "2.5.2")).isTrue();
+  }
+
+  @Test
+  void isNewer_returnsTrueWhenCandidateHasHigherPatch() {
+    assertThat(Launcher.isNewer("2.5.3", "2.5.2")).isTrue();
+  }
+
+  @Test
+  void isNewer_returnsTrueWhenCandidateHasHigherMajor() {
+    assertThat(Launcher.isNewer("3.0.0", "2.5.2")).isTrue();
+  }
+
+  @Test
+  void isNewer_returnsFalseForSameVersion() {
+    assertThat(Launcher.isNewer("2.5.2", "2.5.2")).isFalse();
+  }
+
+  @Test
+  void isNewer_returnsFalseWhenCandidateIsOlder() {
+    assertThat(Launcher.isNewer("2.4.0", "2.5.2")).isFalse();
+  }
+
+  @Test
+  void isNewer_stripsPreReleaseSuffixBeforeComparing() {
+    assertThat(Launcher.isNewer("2.6.0-SNAPSHOT", "2.5.2")).isTrue();
+    assertThat(Launcher.isNewer("2.5.2-RC1", "2.5.2")).isFalse();
+  }
+
+  @Test
+  void isNewer_returnsFalseForUnparseableInput() {
+    assertThat(Launcher.isNewer("not-a-version", "2.5.2")).isFalse();
+    assertThat(Launcher.isNewer("2.6.0", "not-a-version")).isFalse();
+  }
+
+  // ── GitHub API parsing ────────────────────────────────────────────────────
+
+  @Test
+  void fetchLatestRelease_parsesTagNameAndChoosesJarOverWar() throws Exception {
+    String json =
+        """
+        {
+          "tag_name": "v2.6.0",
+          "html_url": "https://example.com/releases/v2.6.0",
+          "assets": [
+            {"browser_download_url": "https://example.com/downloads/app.war"},
+            {"browser_download_url": "https://example.com/downloads/app.jar"}
+          ]
+        }
+        """;
+
+    HttpServer server = startJsonServer("/releases", json);
+    int port = server.getAddress().getPort();
+    System.setProperty("atw.launcher.releases-api", "http://127.0.0.1:" + port + "/releases");
+    try {
+      Launcher.ReleaseInfo info = Launcher.fetchLatestRelease();
+      assertThat(info).isNotNull();
+      assertThat(info.version()).isEqualTo("2.6.0");
+      assertThat(info.jarUrl()).endsWith("app.jar");
+    } finally {
+      System.clearProperty("atw.launcher.releases-api");
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void fetchLatestRelease_returnsNullWhenApiIsUnreachable() throws Exception {
+    System.setProperty("atw.launcher.releases-api", "http://127.0.0.1:1/unreachable");
+    try {
+      assertThat(Launcher.fetchLatestRelease()).isNull();
+    } finally {
+      System.clearProperty("atw.launcher.releases-api");
+    }
+  }
+
+  // ── download + safe swap ──────────────────────────────────────────────────
+
+  @Test
+  void download_fetchesNewJarAndSwapsOldOne(@TempDir Path tempDir) throws Exception {
+    Path oldJar = tempDir.resolve("all-time-wrestling-rpg-2.5.2.jar");
+    Files.write(oldJar, minimalJarBytes());
+
+    HttpServer server = startJarServer(minimalJarBytes());
+    int port = server.getAddress().getPort();
+    try {
+      Launcher.ReleaseInfo release =
+          new Launcher.ReleaseInfo("2.6.0", "http://127.0.0.1:" + port + "/app.jar");
+
+      Path result = Launcher.download(release, tempDir, oldJar);
+
+      assertThat(result).isNotNull();
+      assertThat(tempDir.resolve("all-time-wrestling-rpg-2.6.0.jar")).exists();
+      assertThat(tempDir.resolve("all-time-wrestling-rpg-2.5.2.jar.old")).exists();
+      assertThat(oldJar).doesNotExist();
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void download_handlesFirstRunWithNoExistingJar(@TempDir Path tempDir) throws Exception {
+    HttpServer server = startJarServer(minimalJarBytes());
+    int port = server.getAddress().getPort();
+    try {
+      Launcher.ReleaseInfo release =
+          new Launcher.ReleaseInfo("2.6.0", "http://127.0.0.1:" + port + "/app.jar");
+
+      Path result = Launcher.download(release, tempDir, null);
+
+      assertThat(result).isNotNull();
+      assertThat(tempDir.resolve("all-time-wrestling-rpg-2.6.0.jar")).exists();
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void download_abortsAndPreservesOldJarWhenDownloadIsCorrupt(@TempDir Path tempDir)
+      throws Exception {
+    Path oldJar = tempDir.resolve("all-time-wrestling-rpg-2.5.2.jar");
+    Files.write(oldJar, minimalJarBytes());
+
+    HttpServer server = startJarServer("THIS IS NOT A ZIP".getBytes());
+    int port = server.getAddress().getPort();
+    try {
+      Launcher.ReleaseInfo release =
+          new Launcher.ReleaseInfo("2.6.0", "http://127.0.0.1:" + port + "/app.jar");
+
+      Path result = Launcher.download(release, tempDir, oldJar);
+
+      assertThat(result).isNull();
+      assertThat(oldJar).exists();
+      assertThat(tempDir.resolve("all-time-wrestling-rpg-2.6.0.jar")).doesNotExist();
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void download_returnsNullWhenServerIsUnreachable(@TempDir Path tempDir) throws Exception {
+    Path oldJar = tempDir.resolve("all-time-wrestling-rpg-2.5.2.jar");
+    Files.write(oldJar, minimalJarBytes());
+
+    Launcher.ReleaseInfo release =
+        new Launcher.ReleaseInfo("2.6.0", "http://127.0.0.1:1/unreachable.jar");
+
+    Path result = Launcher.download(release, tempDir, oldJar);
+
+    assertThat(result).isNull();
+    assertThat(oldJar).exists();
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  private static byte[] minimalJarBytes() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+      zos.putNextEntry(new ZipEntry("META-INF/MANIFEST.MF"));
+      zos.write("Manifest-Version: 1.0\n".getBytes());
+      zos.closeEntry();
+    }
+    return baos.toByteArray();
+  }
+
+  private static HttpServer startJsonServer(String path, String json) throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+    byte[] body = json.getBytes();
+    server.createContext(
+        path,
+        exchange -> {
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, body.length);
+          try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body);
+          }
+        });
+    server.start();
+    return server;
+  }
+
+  private static HttpServer startJarServer(byte[] payload) throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.createContext(
+        "/app.jar",
+        exchange -> {
+          exchange.sendResponseHeaders(200, payload.length);
+          try (OutputStream os = exchange.getResponseBody()) {
+            os.write(payload);
+          }
+        });
+    server.start();
+    return server;
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/base/service/UpdateCheckServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/base/service/UpdateCheckServiceTest.java
@@ -1,0 +1,62 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.base.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UpdateCheckServiceTest {
+
+  @Test
+  void isNewer_returnsTrueWhenCandidateHasHigherMinor() {
+    assertThat(UpdateCheckService.isNewer("2.6.0", "2.5.2")).isTrue();
+  }
+
+  @Test
+  void isNewer_returnsTrueWhenCandidateHasHigherPatch() {
+    assertThat(UpdateCheckService.isNewer("2.5.3", "2.5.2")).isTrue();
+  }
+
+  @Test
+  void isNewer_returnsTrueWhenCandidateHasHigherMajor() {
+    assertThat(UpdateCheckService.isNewer("3.0.0", "2.5.2")).isTrue();
+  }
+
+  @Test
+  void isNewer_returnsFalseForSameVersion() {
+    assertThat(UpdateCheckService.isNewer("2.5.2", "2.5.2")).isFalse();
+  }
+
+  @Test
+  void isNewer_returnsFalseWhenCandidateIsOlder() {
+    assertThat(UpdateCheckService.isNewer("2.4.0", "2.5.2")).isFalse();
+  }
+
+  @Test
+  void isNewer_handlesPreReleaseSuffix() {
+    // Pre-release suffix stripped; numeric part compared only
+    assertThat(UpdateCheckService.isNewer("2.6.0-RC1", "2.5.2")).isTrue();
+    assertThat(UpdateCheckService.isNewer("2.5.2-RC1", "2.5.2")).isFalse();
+  }
+
+  @Test
+  void isNewer_returnsFalseForUnparseableVersions() {
+    assertThat(UpdateCheckService.isNewer("not-a-version", "2.5.2")).isFalse();
+    assertThat(UpdateCheckService.isNewer("2.6.0", "not-a-version")).isFalse();
+  }
+}


### PR DESCRIPTION
## Summary

- **Launcher JAR** (`Launcher.java`): zero-dependency bootstrap inside the desktop installer (DMG/MSI/DEB). On every launch it calls the GitHub Releases API, compares versions, downloads the new full-app JAR to the OS data directory (`~/Library/Application Support/ATW/` on macOS, `%APPDATA%\ATW\` on Windows, `~/.local/share/atw/` on Linux), and execs it. Safe swap sequence: `.tmp` → validate ZIP → rename old to `.old` → rename tmp to final, with automatic rollback on crash.
- **In-app update check** (`UpdateCheckService`): async listener on `ApplicationReadyEvent` that publishes `UpdateAvailableEvent`. Skipped for SNAPSHOT builds and air-gapped installs (`atw.update-check.enabled=false`). Notifies all ADMIN accounts via inbox and adds a system-tray menu item + toast.
- **Portable scripts** (`scripts/portable/start-{macos,linux}.sh`, `start-windows.bat`): same logic in shell/PowerShell — curl GitHub API, `sort -V` semver compare, safe swap.
- **Maven `launcher` profile**: builds the thin launcher JAR (`-Pproduction,desktop,launcher`) staged into jpackage-input; desktop installers shrink from ~150 MB to ~60 MB (JRE + 50 KB launcher).

## Test plan

- [x] `mvn test -Dtest=LauncherTest` — 13 tests: version comparison (7), GitHub API parsing (2), download/safe-swap (4) using JDK's built-in `HttpServer` (no new test dependencies)
- [x] `mvn test -Dtest=UpdateCheckServiceTest` — 7 existing tests for `isNewer()` in the Spring service
- [x] Manual: build DMG with `mvn package -Pproduction,desktop,launcher -Djpackage.type=DMG -Djpackage.appVersion=X.Y.Z -DskipTests`; confirm installer produced in `target/dist/`
- [ ] Manual: on first launch from DMG, confirm app JAR downloaded to OS data dir and app starts
- [ ] Manual: rename installed JAR to an older version; relaunch — confirm update prompt and download

https://claude.ai/code/session_014C7nAFHytuvwiRrDwYNzmP