### PR TITLE
feat: extend Extreme campaign — 55 encounters, Proving Ground phase, new match types

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,7 +19,7 @@ doing a simple exact-string sanity check after Repowise already pointed you at a
 
 ## Codebase Intelligence for all-time-wrestling-rpg (Repowise)
 
-Indexed by [Repowise](https://repowise.dev). Last indexed: 2026-07-27 (commit 84eac8604). Confidence: 100%.
+Indexed by [Repowise](https://repowise.dev). Last indexed: 2026-07-27 (commit b920552d8). Confidence: 100%.
 The MCP tools below serve pre-verified docs, symbols, history, and health from that index. Every response carries `_meta` freshness fields; a `stale_warning` appears only when a file the response actually serves changed after indexing — silence means current.
 
 ### How to work in this repo
@@ -75,15 +75,15 @@ repo is a comprehensive wrestling promotion management platform that consumes us
 
 ### Hotspots (high churn — check `get_risk` before editing)
 
-- `package.json` — 65 commits/90d (100.0th %ile)
-- `package-lock.json` — 44 commits/90d (99.9th %ile)
+- `package.json` — 68 commits/90d (100.0th %ile)
+- `package-lock.json` — 45 commits/90d (99.9th %ile)
 - `src/test/resources/db/h2-snapshot-v112.sql` — 6 commits/90d (99.9th %ile)
 - `src/main/java/com/github/javydreamercsw/management/ui/view/show/ShowDetailView.java` — 27 commits/90d (99.8th %ile)
 - `src/test/java/com/github/javydreamercsw/AbstractE2ETest.java` — 18 commits/90d (99.8th %ile)
 
 ### Code health
 
-Three co-equal signals: defect risk 8.08/10 avg, hotspot health 4.94/10 (stable), worst `src/main/java/com/github/javydreamercsw/management/DataInitializer.java` at 1.0/10 · maintainability 8.77/10 · performance risk 315 open static I/O-in-loop / N+1 findings. Detail: `get_health()`.
+Three co-equal signals: defect risk 8.08/10 avg, hotspot health 4.98/10 (stable), worst `src/main/java/com/github/javydreamercsw/management/DataInitializer.java` at 1.0/10 · maintainability 8.77/10 · performance risk 315 open static I/O-in-loop / N+1 findings. Detail: `get_health()`.
 
 Critical files:
 - `src/main/java/com/github/javydreamercsw/management/service/campaign/PlaceholderResolverService.java` — change entropy — impact −3.0

--- a/.repowise/.update.lock
+++ b/.repowise/.update.lock
@@ -1,1 +1,0 @@
-{"pid": 48715, "pid_create_token": "Sun Jul 26 20:15:30 2026", "target_commit": "84eac860476ddab8e345055d1e4feed02760eaba", "started_at": 1785114931.608572}

--- a/src/main/resources/campaigns/extreme/encounters/01_underground_shared.json
+++ b/src/main/resources/campaigns/extreme/encounters/01_underground_shared.json
@@ -67,4 +67,77 @@
     "segmentRules": [ "No DQ" ],
     "forcedOpponentName": "{{RIVAL}}"
   } ]
+}, {
+  "id": "underground_crowd_brawl",
+  "title": "Riot in the Aisle",
+  "narrativeText": "The guardrail collapses. Fans scatter. The brawl spills from the ring into the crowd. There is no ring anymore — the whole building is the arena. Three other wrestlers are already out here. This has become something else entirely.",
+  "choices": [ {
+    "id": "join_the_riot",
+    "label": "Join the Riot",
+    "text": "You dive into the chaos. It's every person for themselves.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "Free-for-All",
+    "segmentRules": [ "Free-For-All" ]
+  }, {
+    "id": "reclaim_the_ring",
+    "label": "Reclaim the Ring",
+    "text": "While everyone brawls outside, you hold the ring. The crowd respects the strategy.",
+    "vpReward": 1,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": -1
+  } ]
+}, {
+  "id": "underground_outsider_test",
+  "title": "The Outsider's Test",
+  "narrativeText": "A masked figure steps through the curtain. No music. No introduction. They point at you. The underground booker announces: this is an elimination challenge. Beat them, and your name stays on the board. Lose, and you go to the back of the line.",
+  "choices": [ {
+    "id": "accept_outsider",
+    "label": "Accept the Challenge",
+    "text": "Prove you belong here.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "Elimination" ]
+  } ]
+}, {
+  "id": "underground_locker_room_message",
+  "title": "Threat on the Locker",
+  "narrativeText": "Taped to your locker, written in marker on a paper towel: 'You're next. And you won't get up.' No name. No explanation. The smell of sweat and blood fills the room around you.",
+  "choices": [ {
+    "id": "ignore_threat",
+    "label": "Ignore It",
+    "text": "Anonymous cowards don't deserve a response. You crumple it and toss it.",
+    "vpReward": 0,
+    "nextPhase": "BACKSTAGE"
+  }, {
+    "id": "post_counter",
+    "label": "Post a Counter-Threat",
+    "text": "You write your own note and pin it to the corkboard where everyone will see it.",
+    "vpReward": 0,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": -1,
+    "featureFlags": {
+      "accepted_locker_challenge": true
+    }
+  } ]
+}, {
+  "id": "underground_fan_chant",
+  "title": "The Parking Lot Chant",
+  "narrativeText": "Outside the venue, a group of fans in the parking lot starts chanting your name before the show even starts. Word must have spread. They are here for you — holding handmade signs, wearing your colors, waiting.",
+  "choices": [ {
+    "id": "acknowledge_fans",
+    "label": "Stop and Acknowledge Them",
+    "text": "You walk over. Slap hands. Point to the building. They roar.",
+    "vpReward": 1,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": 2
+  }, {
+    "id": "stay_in_character",
+    "label": "Walk Past in Character",
+    "text": "You're the bad guy tonight. No time for sentiment.",
+    "vpReward": 0,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": -1
+  } ]
 } ]

--- a/src/main/resources/campaigns/extreme/encounters/02_underground_rvd.json
+++ b/src/main/resources/campaigns/extreme/encounters/02_underground_rvd.json
@@ -12,4 +12,19 @@
     "matchType": "One on One",
     "segmentRules": [ "No DQ" ]
   } ]
+}, {
+  "id": "rvd_rolling_thunder_extreme",
+  "requiredWrestlerName": "Rob Van Dam",
+  "title": "Rolling Thunder",
+  "narrativeText": "The crowd is already chanting your initials. The opponent stands in the center of the ring trying to look unimpressed. You run the ropes — Rolling Thunder. The building erupts. No DQ means no limits on what comes next.",
+  "choices": [ {
+    "id": "rolling_thunder_attack",
+    "label": "Rolling Thunder Into the Brawl",
+    "text": "The signature move opens the door. Now finish what you started.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "No DQ" ],
+    "alignmentShift": 1
+  } ]
 } ]

--- a/src/main/resources/campaigns/extreme/encounters/03_underground_sabu.json
+++ b/src/main/resources/campaigns/extreme/encounters/03_underground_sabu.json
@@ -13,4 +13,18 @@
     "segmentRules": [ "Last Man Standing" ],
     "forcedOpponentName": "{{RIVAL}}"
   } ]
+}, {
+  "id": "sabu_chair_frenzy",
+  "requiredWrestlerName": "Sabu",
+  "title": "Chair Frenzy",
+  "narrativeText": "A folding steel chair is both a weapon and a launching pad for Sabu. He springboards off it, flies through the air, crashes into his opponent, stands up and does it again. The crowd loses their minds. Then three more wrestlers slide into the ring.",
+  "choices": [ {
+    "id": "use_chair_as_weapon",
+    "label": "Springboard Into Chaos",
+    "text": "Chair. Launch. Impact. Repeat. Homicidal, suicidal, genocidal.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "Free-for-All",
+    "segmentRules": [ "Free-For-All" ]
+  } ]
 } ]

--- a/src/main/resources/campaigns/extreme/encounters/04_underground_raven.json
+++ b/src/main/resources/campaigns/extreme/encounters/04_underground_raven.json
@@ -16,4 +16,19 @@
       "raven_quote_delivered": true
     }
   } ]
+}, {
+  "id": "raven_concrete_ddt",
+  "requiredWrestlerName": "Raven",
+  "title": "Concrete Revelation",
+  "narrativeText": "Raven doesn't wait for the ring. He takes the fight to the concrete floor outside, where there are no ropes and no rules even attempted. He whips the opponent into the guardrail, then drops — DDT on the bare floor. The crowd goes absolutely silent, then erupts.",
+  "choices": [ {
+    "id": "ddt_on_concrete",
+    "label": "Take It to the Floor",
+    "text": "The ring is a suggestion. The concrete is where the truth lives.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "No DQ" ],
+    "alignmentShift": -2
+  } ]
 } ]

--- a/src/main/resources/campaigns/extreme/encounters/05_underground_daemon.json
+++ b/src/main/resources/campaigns/extreme/encounters/05_underground_daemon.json
@@ -12,4 +12,19 @@
     "matchType": "One on One",
     "segmentRules": [ "Last Man Standing" ]
   } ]
+}, {
+  "id": "daemon_lights_out",
+  "requiredWrestlerName": "Daemon",
+  "title": "Lights Out",
+  "narrativeText": "Daemon reaches into the circuit breaker panel behind the curtain and kills the main lights. The building goes completely dark. The crowd screams — not in fear, in anticipation. When the emergency lighting flickers on (dim, red-tinged), Daemon is already in the ring.",
+  "choices": [ {
+    "id": "fight_in_the_dark",
+    "label": "Fight in the Dark",
+    "text": "Your opponent can't see you. You don't need to see them.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "No DQ" ],
+    "alignmentShift": -1
+  } ]
 } ]

--- a/src/main/resources/campaigns/extreme/encounters/06_championship_shared.json
+++ b/src/main/resources/campaigns/extreme/encounters/06_championship_shared.json
@@ -24,7 +24,8 @@
     "nextPhase": "MATCH",
     "matchType": "One on One",
     "segmentRules": [ "No DQ" ],
-    "forcedOpponentName": "{{CHAMP}}"
+    "forcedOpponentName": "{{CHAMP}}",
+    "onLossNextEncounterId": "comeback_betrayal"
   } ]
 }, {
   "id": "championship_defense",
@@ -52,5 +53,182 @@
     "nextPhase": "MATCH",
     "matchType": "One on One",
     "segmentRules": [ "Last Man Standing" ]
+  } ]
+}, {
+  "id": "championship_ladder_shot",
+  "title": "Contract on the Line",
+  "narrativeText": "The booker has a new idea: hang a briefcase containing a championship contract above the ring. Win it, and you secure your spot. A ladder match. The crowd is already buzzing.",
+  "choices": [ {
+    "id": "climb_the_ladder",
+    "label": "Climb for the Contract",
+    "text": "Every rung is a battle. The contract is yours.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "Ladder Match" ]
+  } ]
+}, {
+  "id": "championship_dirty_politics",
+  "title": "Booker's Ultimatum",
+  "narrativeText": "The booker calls you into his office. He slides a paper across the desk. 'Sign this or I strip the title.' The paper would give him creative control of your character. The crowd outside is chanting your name, not his.",
+  "choices": [ {
+    "id": "comply_with_booker",
+    "label": "Sign It",
+    "text": "You need the belt. You swallow your pride and sign.",
+    "vpReward": 0,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": -2
+  }, {
+    "id": "call_his_bluff",
+    "label": "Call His Bluff",
+    "text": "You tear the paper in half. 'Try it. See what the crowd does.' He backs down.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "No DQ" ],
+    "alignmentShift": 2,
+    "featureFlags": {
+      "challenged_booker": true
+    }
+  } ]
+}, {
+  "id": "championship_hardcore_gauntlet",
+  "title": "Extreme Gauntlet",
+  "narrativeText": "The announcement comes with no warning: tonight, you defend against a gauntlet of challengers. They come one by one until you can no longer stand. The crowd is ecstatic. You are less so.",
+  "choices": [ {
+    "id": "run_the_gauntlet",
+    "label": "Run the Gauntlet",
+    "text": "Survive long enough and the championship stays yours.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "Gauntlet" ]
+  } ]
+}, {
+  "id": "championship_press_war",
+  "title": "Promo War",
+  "narrativeText": "{{RIVAL}} cuts a promo on cable TV — calling you a paper champion, saying you got lucky, that the title never belonged to you. It airs. The calls start. The booker wants a response by midnight.",
+  "choices": [ {
+    "id": "respond_publicly",
+    "label": "Fire Back Publicly",
+    "text": "You call in to the show and say everything. The fans eat it up.",
+    "vpReward": 1,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": 1
+  }, {
+    "id": "no_comment",
+    "label": "No Comment",
+    "text": "You let actions speak louder than words. Next week in the ring.",
+    "vpReward": 0,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": -1,
+    "featureFlags": {
+      "stayed_silent": true
+    }
+  } ]
+}, {
+  "id": "championship_faction_offer",
+  "title": "The Faction",
+  "narrativeText": "Three wrestlers corner you after the show. Their leader slides you a card. 'Join us. We'll make sure no one touches that title without going through all of us first.' They seem sincere. They are also terrifying.",
+  "choices": [ {
+    "id": "join_faction",
+    "label": "Accept the Offer",
+    "text": "Numbers matter in the extreme world. You're in.",
+    "vpReward": 0,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": -3
+  }, {
+    "id": "refuse_faction",
+    "label": "Refuse",
+    "text": "You got here alone. You'll keep it that way.",
+    "vpReward": 0,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": 2,
+    "featureFlags": {
+      "refused_faction": true
+    }
+  } ]
+}, {
+  "id": "championship_injury_scare",
+  "title": "Grinding Through",
+  "narrativeText": "Your knee buckles in warmup. The trainer wraps it, says two words: 'Be careful.' You have a championship defense tonight. The crowd is already in their seats.",
+  "choices": [ {
+    "id": "push_through_injury",
+    "label": "Push Through",
+    "text": "Champions don't take nights off. You tape it tight and head to the ring.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "No DQ" ]
+  }, {
+    "id": "take_a_week",
+    "label": "Rest It",
+    "text": "You request a one-week postponement. The crowd boos, but the knee needs time.",
+    "vpReward": 2,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": -1
+  } ]
+}, {
+  "id": "championship_tlc_brawl",
+  "title": "Tables, Ladders and Chairs",
+  "narrativeText": "{{RIVAL}} drags a ladder down the aisle on their way to the ring. A ring crew member follows with a stack of tables. Someone has informed the crowd this is happening. They are already standing.",
+  "choices": [ {
+    "id": "embrace_the_tlc",
+    "label": "Embrace the Chaos",
+    "text": "Tables. Ladders. Chairs. You helped invent this match.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "Tables, Ladders and Chairs (TLC)" ],
+    "forcedOpponentName": "{{RIVAL}}"
+  } ]
+}, {
+  "id": "comeback_betrayal",
+  "title": "Thrown Under the Bus",
+  "narrativeText": "The locker room clears out fast after your loss. Someone — a person you considered an ally — is on the house microphone, telling the crowd you were never good enough, that the belt was always above your reach. The words echo in the empty hallway.",
+  "choices": [ {
+    "id": "regroup_alone",
+    "label": "Face It Alone",
+    "text": "You say nothing. You find a quiet corner and start planning. This is not over.",
+    "vpReward": 0,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": 1,
+    "nextEncounterId": "comeback_fan_support"
+  }, {
+    "id": "demand_rematch_now",
+    "label": "Demand a Rematch Tonight",
+    "text": "You storm back to the ring. You are not done. Not even close.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "No DQ" ],
+    "alignmentShift": -1
+  } ]
+}, {
+  "id": "comeback_fan_support",
+  "title": "Standing Ovation",
+  "narrativeText": "One fan finds you in the parking lot. Then two. Then a dozen. They are still wearing your shirts. One holds a sign: 'WE BELIEVE.' They did not leave when you lost. You are not going to let them down.",
+  "choices": [ {
+    "id": "channel_the_support",
+    "label": "Channel the Support",
+    "text": "You shake every hand. You remember why you do this. The comeback starts now.",
+    "vpReward": 1,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": 1,
+    "nextEncounterId": "comeback_qualifier"
+  } ]
+}, {
+  "id": "comeback_qualifier",
+  "title": "Second Chance Qualifier",
+  "narrativeText": "The booker posts the bracket: an elimination qualifier. Win it and you re-earn the championship match. The crowd knows what is at stake. They are on their feet before the bell.",
+  "choices": [ {
+    "id": "win_the_qualifier",
+    "label": "Fight Your Way Back",
+    "text": "Elimination. One by one, you take them all down.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "Elimination" ],
+    "onWinNextEncounterId": "title_shot_earned"
   } ]
 } ]

--- a/src/main/resources/campaigns/extreme/encounters/07_championship_rvd.json
+++ b/src/main/resources/campaigns/extreme/encounters/07_championship_rvd.json
@@ -12,4 +12,26 @@
     "matchType": "One on One",
     "segmentRules": [ "No DQ" ]
   } ]
+}, {
+  "id": "rvd_champion_spotlight",
+  "requiredWrestlerName": "Rob Van Dam",
+  "title": "Champion's Spotlight",
+  "narrativeText": "The production crew wants a photo op with the belt. The interviewer shoves a microphone in your face. The crowd is chanting R-V-D. This is the moment — you can be everything they want, or remind them why you are dangerous.",
+  "choices": [ {
+    "id": "fire_up_crowd_rvd",
+    "label": "Fire Up the Crowd",
+    "text": "You point to yourself, then the belt, then every corner of the arena. They explode.",
+    "vpReward": 1,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": 2
+  }, {
+    "id": "show_the_teeth",
+    "label": "Show the Teeth",
+    "text": "The championship has made you a target. Time to remind everyone why that is a mistake.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "No DQ" ],
+    "alignmentShift": -1
+  } ]
 } ]

--- a/src/main/resources/campaigns/extreme/encounters/08_championship_sabu.json
+++ b/src/main/resources/campaigns/extreme/encounters/08_championship_sabu.json
@@ -12,4 +12,19 @@
     "matchType": "One on One",
     "segmentRules": [ "Last Man Standing" ]
   } ]
+}, {
+  "id": "sabu_table_setup",
+  "requiredWrestlerName": "Sabu",
+  "title": "The Setup",
+  "narrativeText": "Before the match is even announced, Sabu is already out there. He drags three tables from beneath the ring, stacks them at different corners, and sets a ladder in the center of the ring. The challenger watches from the ramp, visibly reconsidering their choices.",
+  "choices": [ {
+    "id": "sabu_tlc_assault",
+    "label": "Build the Battlefield",
+    "text": "Everything Sabu does is a set piece. Let them see what is coming.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "Tables, Ladders and Chairs (TLC)" ],
+    "alignmentShift": -1
+  } ]
 } ]

--- a/src/main/resources/campaigns/extreme/encounters/09_championship_raven.json
+++ b/src/main/resources/campaigns/extreme/encounters/09_championship_raven.json
@@ -13,4 +13,27 @@
     "segmentRules": [ "No DQ" ],
     "alignmentShift": -1
   } ]
+}, {
+  "id": "raven_mind_games",
+  "requiredWrestlerName": "Raven",
+  "title": "Mind Games",
+  "narrativeText": "Raven leaves a hand-written note on the champion's car windshield. The note lists, in precise detail, every mistake the champion has made over the last six months. Below the list, just one line: 'I know all of them.' It is not a threat. It is worse. It is a diagnosis.",
+  "choices": [ {
+    "id": "ignore_raven_note",
+    "label": "Ignore It",
+    "text": "You throw the note in the trash. Mind games only work if you play.",
+    "vpReward": 1,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": 1
+  }, {
+    "id": "confront_raven",
+    "label": "Confront Him",
+    "text": "You find Raven backstage and tell him exactly where he can put his diagnosis.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "No DQ" ],
+    "alignmentShift": -1,
+    "forcedOpponentName": "Raven"
+  } ]
 } ]

--- a/src/main/resources/campaigns/extreme/encounters/10_championship_daemon.json
+++ b/src/main/resources/campaigns/extreme/encounters/10_championship_daemon.json
@@ -12,4 +12,26 @@
     "matchType": "One on One",
     "segmentRules": [ "Last Man Standing" ]
   } ]
+}, {
+  "id": "daemon_territorial",
+  "requiredWrestlerName": "Daemon",
+  "title": "Territorial",
+  "narrativeText": "Daemon has claimed the entire backstage area as his domain. He stands at the locker room entrance and will not move. Catering, production, other wrestlers — all of them take the long way around. The champion comes through next. Daemon does not step aside.",
+  "choices": [ {
+    "id": "back_down",
+    "label": "Take the Long Way",
+    "text": "This isn't the fight worth having tonight. You circle around.",
+    "vpReward": 1,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": -1
+  }, {
+    "id": "claim_the_territory",
+    "label": "Stand Your Ground",
+    "text": "Your locker room. Your hallway. Your championship. Nobody moves you.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "No DQ" ],
+    "alignmentShift": 1
+  } ]
 } ]

--- a/src/main/resources/campaigns/extreme/encounters/10a_proving_shared.json
+++ b/src/main/resources/campaigns/extreme/encounters/10a_proving_shared.json
@@ -1,0 +1,77 @@
+[ {
+  "id": "proving_war_games",
+  "title": "War of Attrition",
+  "narrativeText": "Two rings. One massive steel cage bolted over both of them. Your team enters first. Their team enters one by one at timed intervals. Once everyone is inside, the Match Beyond begins. This is not a championship match. This is a war. The winner proves they can survive anything.",
+  "choices": [ {
+    "id": "enter_war_games",
+    "label": "Enter the Cage",
+    "text": "You lead your team in. The cage door locks behind you.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "Free-for-All",
+    "segmentRules": [ "🪖 War Games" ]
+  } ]
+}, {
+  "id": "proving_contract_signing_tlc",
+  "title": "Contract Signing Chaos",
+  "narrativeText": "The booker sets up a table center-ring for a contract signing. Both sides stand on opposite sides. The documents are there. The pens are there. The ladders and chairs set up 'for decoration' are also there. The crowd knows this is not going to be a simple signing.",
+  "choices": [ {
+    "id": "sign_then_swing",
+    "label": "Sign, Then Swing",
+    "text": "You sign your name. Then you flip the table.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "Tables, Ladders and Chairs (TLC)" ],
+    "forcedOpponentName": "{{RIVAL}}"
+  } ]
+}, {
+  "id": "proving_betrayal_setup",
+  "title": "The Stab in the Back",
+  "narrativeText": "Someone in your corner — someone who was supposed to have your back — attacks you from behind after the match. While you're still down on the mat, they take the microphone and side with your enemies. The crowd is stunned silent.",
+  "choices": [ {
+    "id": "fight_back_immediately",
+    "label": "Fight Back Now",
+    "text": "You get up. Bloodied, exhausted, and furious — you get up.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "No DQ" ],
+    "alignmentShift": 1
+  }, {
+    "id": "absorb_the_betrayal",
+    "label": "Absorb It",
+    "text": "You let them say their piece. You remember every word. And you leave quietly, already planning.",
+    "vpReward": 2,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": 1,
+    "featureFlags": {
+      "survived_betrayal": true
+    }
+  } ]
+}, {
+  "id": "proving_championship_press",
+  "title": "Pre-Finale Media",
+  "narrativeText": "Two reporters and a camera crew are waiting outside the arena. The Barbwire Exploding Deathmatch has been announced. They want a statement. The camera is live. The whole world is watching.",
+  "choices": [ {
+    "id": "embrace_the_extreme",
+    "label": "Embrace the Extreme",
+    "text": "'I have been waiting my entire career for a match like this.' The crowd watching at home loses their minds.",
+    "vpReward": 0,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": 2,
+    "featureFlags": {
+      "media_statement_made": true
+    }
+  }, {
+    "id": "stare_into_camera",
+    "label": "Stare Into the Camera",
+    "text": "No words. You look directly into the lens for ten full seconds, then walk away. The silence is louder than anything you could have said.",
+    "vpReward": 0,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": -2,
+    "featureFlags": {
+      "media_statement_made": true
+    }
+  } ]
+} ]

--- a/src/main/resources/campaigns/extreme/encounters/10b_proving_rvd.json
+++ b/src/main/resources/campaigns/extreme/encounters/10b_proving_rvd.json
@@ -1,0 +1,16 @@
+[ {
+  "id": "rvd_proving_aerial",
+  "requiredWrestlerName": "Rob Van Dam",
+  "title": "Title Defense Aerial",
+  "narrativeText": "The championship contract is suspended above the ring from a cable. R-V-D has exactly one option: climb. But first, you have to get past the person who rips the ladder away every time you set it up. The crowd is chanting. The ladder is across the ring.",
+  "choices": [ {
+    "id": "rvd_ladder_climb",
+    "label": "Use the Ladder",
+    "text": "You are the most athletic person in this building. Prove it.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "Ladder Match" ],
+    "alignmentShift": 1
+  } ]
+} ]

--- a/src/main/resources/campaigns/extreme/encounters/10c_proving_sabu.json
+++ b/src/main/resources/campaigns/extreme/encounters/10c_proving_sabu.json
@@ -1,0 +1,16 @@
+[ {
+  "id": "sabu_proving_table",
+  "requiredWrestlerName": "Sabu",
+  "title": "Table Spot",
+  "narrativeText": "Sabu has positioned a table leaning against the turnbuckle, another flat on the outside. A ladder stands center-ring. His opponent is across from him, arms wide, daring him to try something. Sabu does not need to be dared.",
+  "choices": [ {
+    "id": "sabu_tlc_proving",
+    "label": "Make the Most Extreme Spot in History",
+    "text": "Homicidal. Suicidal. Genocidal. Curtain call.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "One on One",
+    "segmentRules": [ "Tables, Ladders and Chairs (TLC)" ],
+    "alignmentShift": -1
+  } ]
+} ]

--- a/src/main/resources/campaigns/extreme/encounters/10d_proving_raven.json
+++ b/src/main/resources/campaigns/extreme/encounters/10d_proving_raven.json
@@ -1,0 +1,17 @@
+[ {
+  "id": "raven_proving_monologue",
+  "requiredWrestlerName": "Raven",
+  "title": "The Manifesto",
+  "narrativeText": "Raven takes the microphone before the match is even announced. He sits cross-legged in the center of the ring. He speaks — not at the crowd, but at himself, as if working through something. His words form a manifesto: about pain, about purpose, about the barbwire that awaits. The arena goes utterly quiet.",
+  "choices": [ {
+    "id": "deliver_the_manifesto",
+    "label": "Deliver the Manifesto",
+    "text": "Every word is a wound. The crowd listens to every single one.",
+    "vpReward": 0,
+    "nextPhase": "BACKSTAGE",
+    "alignmentShift": -2,
+    "featureFlags": {
+      "raven_monologue": true
+    }
+  } ]
+} ]

--- a/src/main/resources/campaigns/extreme/encounters/10e_proving_daemon.json
+++ b/src/main/resources/campaigns/extreme/encounters/10e_proving_daemon.json
@@ -1,0 +1,16 @@
+[ {
+  "id": "daemon_proving_pain",
+  "requiredWrestlerName": "Daemon",
+  "title": "Welcome the Pain",
+  "narrativeText": "Daemon does not warm up. Daemon does not stretch. Daemon stands in the corner of his side of the cage, watching both teams enter. When the door locks, the other team looks at their numbers advantage. Daemon looks at them the way someone surveys a buffet.",
+  "choices": [ {
+    "id": "daemon_war_games_choice",
+    "label": "Welcome the Pain",
+    "text": "The cage is where Daemon lives. They walked into your world.",
+    "vpReward": 0,
+    "nextPhase": "MATCH",
+    "matchType": "Free-for-All",
+    "segmentRules": [ "🪖 War Games" ],
+    "alignmentShift": -1
+  } ]
+} ]

--- a/src/test/java/com/github/javydreamercsw/management/service/campaign/ExtremeCampaignChapterTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/campaign/ExtremeCampaignChapterTest.java
@@ -96,6 +96,28 @@ class ExtremeCampaignChapterTest {
         .findFirst();
   }
 
+  private StaticEncounterDTO findEncounterInPathA(final String encounterId) {
+    return findChapter(PATH_A_ID)
+        .map(
+            ch ->
+                ch.getStaticEncounters().stream()
+                    .filter(e -> encounterId.equals(e.getId()))
+                    .findFirst()
+                    .orElse(null))
+        .orElse(null);
+  }
+
+  private StaticEncounterDTO.StaticChoiceDTO findChoice(
+      final StaticEncounterDTO encounter, final String choiceId) {
+    if (encounter == null || encounter.getChoices() == null) {
+      return null;
+    }
+    return encounter.getChoices().stream()
+        .filter(c -> choiceId.equals(c.getId()))
+        .findFirst()
+        .orElse(null);
+  }
+
   // ---------------------------------------------------------------------------
   // Path A — wrestler restriction
   // ---------------------------------------------------------------------------
@@ -218,8 +240,8 @@ class ExtremeCampaignChapterTest {
             .filter(e -> e.getRequiredWrestlerName() == null)
             .toList();
 
-    // Underground (4) + Championship (4) + Finale (5) shared cards = 13 total
-    assertThat(shared).hasSizeGreaterThanOrEqualTo(11);
+    // Underground (8) + Championship (14) + Proving (4) + Finale (5) shared cards = 31 total
+    assertThat(shared).hasSizeGreaterThanOrEqualTo(25);
   }
 
   // ---------------------------------------------------------------------------
@@ -298,5 +320,238 @@ class ExtremeCampaignChapterTest {
     assertThat(available)
         .extracting(CampaignChapterDTO::getId)
         .doesNotContain(PATH_A_ID, PATH_B_ID);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Win/loss branching — title shot loss creates a comeback arc
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("Losing the title shot routes to the comeback_betrayal encounter")
+  void titleShotLoss_routesToComebackBetrayal() {
+    StaticEncounterDTO encounter = findEncounterInPathA("title_shot_earned");
+    assertThat(encounter).as("title_shot_earned must exist in Path A").isNotNull();
+
+    StaticEncounterDTO.StaticChoiceDTO choice = findChoice(encounter, "challenge_for_title");
+    assertThat(choice).as("challenge_for_title choice must exist").isNotNull();
+    assertThat(choice.getOnLossNextEncounterId())
+        .as("Loss from title shot must route to comeback_betrayal")
+        .isEqualTo("comeback_betrayal");
+  }
+
+  @Test
+  @DisplayName("comeback_betrayal regroup choice routes to comeback_fan_support")
+  void comebackArc_betray_routesToFanSupport() {
+    StaticEncounterDTO encounter = findEncounterInPathA("comeback_betrayal");
+    assertThat(encounter).as("comeback_betrayal must exist in Path A").isNotNull();
+
+    StaticEncounterDTO.StaticChoiceDTO choice = findChoice(encounter, "regroup_alone");
+    assertThat(choice).as("regroup_alone choice must exist in comeback_betrayal").isNotNull();
+    assertThat(choice.getNextEncounterId())
+        .as("Regroup choice must route to comeback_fan_support")
+        .isEqualTo("comeback_fan_support");
+  }
+
+  @Test
+  @DisplayName("comeback_fan_support routes to comeback_qualifier")
+  void comebackArc_fanSupport_routesToQualifier() {
+    StaticEncounterDTO encounter = findEncounterInPathA("comeback_fan_support");
+    assertThat(encounter).as("comeback_fan_support must exist in Path A").isNotNull();
+
+    StaticEncounterDTO.StaticChoiceDTO choice = findChoice(encounter, "channel_the_support");
+    assertThat(choice).as("channel_the_support choice must exist").isNotNull();
+    assertThat(choice.getNextEncounterId())
+        .as("Fan support must route to comeback_qualifier")
+        .isEqualTo("comeback_qualifier");
+  }
+
+  @Test
+  @DisplayName("Winning comeback_qualifier routes back to title_shot_earned")
+  void comebackArc_qualifier_winRoutesBackToTitleShot() {
+    StaticEncounterDTO encounter = findEncounterInPathA("comeback_qualifier");
+    assertThat(encounter).as("comeback_qualifier must exist in Path A").isNotNull();
+
+    StaticEncounterDTO.StaticChoiceDTO choice = findChoice(encounter, "win_the_qualifier");
+    assertThat(choice).as("win_the_qualifier choice must exist").isNotNull();
+    assertThat(choice.getOnWinNextEncounterId())
+        .as("Qualifier win must route back to title_shot_earned")
+        .isEqualTo("title_shot_earned");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Proving Ground phase — new 4th phase encounters
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("Proving Ground shared encounters exist in Path A")
+  void provingGround_sharedEncountersExist() {
+    Optional<CampaignChapterDTO> chapter = findChapter(PATH_A_ID);
+    assertThat(chapter).isPresent();
+
+    List<String> ids =
+        chapter.get().getStaticEncounters().stream().map(StaticEncounterDTO::getId).toList();
+
+    assertThat(ids)
+        .as("All four Proving Ground shared encounters must be present")
+        .contains(
+            "proving_war_games",
+            "proving_contract_signing_tlc",
+            "proving_betrayal_setup",
+            "proving_championship_press");
+  }
+
+  @Test
+  @DisplayName("Proving Ground wrestler-specific encounters exist for all four wrestlers")
+  void provingGround_wrestlerSpecificEncountersExist() {
+    Optional<CampaignChapterDTO> chapter = findChapter(PATH_A_ID);
+    assertThat(chapter).isPresent();
+
+    List<String> ids =
+        chapter.get().getStaticEncounters().stream().map(StaticEncounterDTO::getId).toList();
+
+    assertThat(ids)
+        .as("Proving Ground wrestler-specific encounters must exist for RVD, Sabu, Raven, Daemon")
+        .contains(
+            "rvd_proving_aerial",
+            "sabu_proving_table",
+            "raven_proving_monologue",
+            "daemon_proving_pain");
+  }
+
+  @Test
+  @DisplayName("Proving Ground RVD encounter has requiredWrestlerName = Rob Van Dam")
+  void provingGround_rvd_hasWrestlerRestriction() {
+    StaticEncounterDTO encounter = findEncounterInPathA("rvd_proving_aerial");
+    assertThat(encounter).as("rvd_proving_aerial must exist").isNotNull();
+    assertThat(encounter.getRequiredWrestlerName()).isEqualTo("Rob Van Dam");
+  }
+
+  @Test
+  @DisplayName("Proving Ground Raven encounter has requiredWrestlerName = Raven")
+  void provingGround_raven_hasWrestlerRestriction() {
+    StaticEncounterDTO encounter = findEncounterInPathA("raven_proving_monologue");
+    assertThat(encounter).as("raven_proving_monologue must exist").isNotNull();
+    assertThat(encounter.getRequiredWrestlerName()).isEqualTo("Raven");
+  }
+
+  // ---------------------------------------------------------------------------
+  // New match types — all six custom types present in Path A
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("All six new match types are present in at least one Path A encounter choice")
+  void newMatchTypes_allSixPresentInPathA() {
+    Optional<CampaignChapterDTO> chapter = findChapter(PATH_A_ID);
+    assertThat(chapter).isPresent();
+
+    List<String> allRules =
+        chapter.get().getStaticEncounters().stream()
+            .filter(e -> e.getChoices() != null)
+            .flatMap(e -> e.getChoices().stream())
+            .filter(c -> c.getSegmentRules() != null)
+            .flatMap(c -> c.getSegmentRules().stream())
+            .toList();
+
+    assertThat(allRules)
+        .as("Free-For-All must appear in at least one choice")
+        .contains("Free-For-All");
+    assertThat(allRules)
+        .as("Elimination must appear in at least one choice")
+        .contains("Elimination");
+    assertThat(allRules)
+        .as("Ladder Match must appear in at least one choice")
+        .contains("Ladder Match");
+    assertThat(allRules)
+        .as("TLC must appear in at least one choice")
+        .contains("Tables, Ladders and Chairs (TLC)");
+    assertThat(allRules).as("Gauntlet must appear in at least one choice").contains("Gauntlet");
+    assertThat(allRules)
+        .as("War Games must appear in at least one choice")
+        .contains("🪖 War Games");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Feature flags — choices that set flags used by exit criteria and branching
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("underground_locker_room_message sets accepted_locker_challenge featureFlag")
+  void featureFlag_acceptedLockerChallenge_setByChoice() {
+    StaticEncounterDTO encounter = findEncounterInPathA("underground_locker_room_message");
+    assertThat(encounter).as("underground_locker_room_message must exist in Path A").isNotNull();
+
+    boolean flagSet =
+        encounter.getChoices().stream()
+            .filter(c -> c.getFeatureFlags() != null)
+            .anyMatch(
+                c -> Boolean.TRUE.equals(c.getFeatureFlags().get("accepted_locker_challenge")));
+
+    assertThat(flagSet)
+        .as("A choice in underground_locker_room_message must set accepted_locker_challenge=true")
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("championship_dirty_politics sets challenged_booker featureFlag")
+  void featureFlag_challengedBooker_setByChoice() {
+    StaticEncounterDTO encounter = findEncounterInPathA("championship_dirty_politics");
+    assertThat(encounter).as("championship_dirty_politics must exist in Path A").isNotNull();
+
+    boolean flagSet =
+        encounter.getChoices().stream()
+            .filter(c -> c.getFeatureFlags() != null)
+            .anyMatch(c -> Boolean.TRUE.equals(c.getFeatureFlags().get("challenged_booker")));
+
+    assertThat(flagSet)
+        .as("A choice in championship_dirty_politics must set challenged_booker=true")
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("championship_faction_offer sets refused_faction featureFlag")
+  void featureFlag_refusedFaction_setByChoice() {
+    StaticEncounterDTO encounter = findEncounterInPathA("championship_faction_offer");
+    assertThat(encounter).as("championship_faction_offer must exist in Path A").isNotNull();
+
+    boolean flagSet =
+        encounter.getChoices().stream()
+            .filter(c -> c.getFeatureFlags() != null)
+            .anyMatch(c -> Boolean.TRUE.equals(c.getFeatureFlags().get("refused_faction")));
+
+    assertThat(flagSet)
+        .as("A choice in championship_faction_offer must set refused_faction=true")
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("proving_betrayal_setup sets survived_betrayal featureFlag")
+  void featureFlag_survivedBetrayal_setByChoice() {
+    StaticEncounterDTO encounter = findEncounterInPathA("proving_betrayal_setup");
+    assertThat(encounter).as("proving_betrayal_setup must exist in Path A").isNotNull();
+
+    boolean flagSet =
+        encounter.getChoices().stream()
+            .filter(c -> c.getFeatureFlags() != null)
+            .anyMatch(c -> Boolean.TRUE.equals(c.getFeatureFlags().get("survived_betrayal")));
+
+    assertThat(flagSet)
+        .as("A choice in proving_betrayal_setup must set survived_betrayal=true")
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("raven_proving_monologue sets raven_monologue featureFlag")
+  void featureFlag_ravenMonologue_setByChoice() {
+    StaticEncounterDTO encounter = findEncounterInPathA("raven_proving_monologue");
+    assertThat(encounter).as("raven_proving_monologue must exist in Path A").isNotNull();
+
+    boolean flagSet =
+        encounter.getChoices().stream()
+            .filter(c -> c.getFeatureFlags() != null)
+            .anyMatch(c -> Boolean.TRUE.equals(c.getFeatureFlags().get("raven_monologue")));
+
+    assertThat(flagSet)
+        .as("A choice in raven_proving_monologue must set raven_monologue=true")
+        .isTrue();
   }
 }


### PR DESCRIPTION
## Summary
Extends The Extreme Path campaign from 23 to **55 interactive encounter records** across four phases, and adds comprehensive test coverage for all new paths.

- **Underground**: +4 shared encounters (Free-For-All riot, Elimination outsider test, locker-room threat, parking-lot fan chant) + 1 more wrestler-specific encounter per wrestler
- **Championship**: +7 shared encounters (Ladder Match contract shot, Booker's Ultimatum with BACKSTAGE/No DQ choice, Extreme Gauntlet, Promo War, Faction offer, Injury scare, TLC brawl) + 1 more wrestler-specific per wrestler
- **Win/loss branching**: losing the title shot now routes through a 3-encounter comeback arc (betrayal → fan support → Elimination qualifier → rematch opportunity) instead of just losing VP
- **Proving Ground (new 4th phase)**: 4 shared + 4 wrestler-specific encounters before the finale, including War Games and TLC
- **6 new match types**: Free-For-All, Elimination, Ladder Match, Tables/Ladders/Chairs (TLC), Gauntlet, 🪖 War Games — all previously unused in the campaign
- **Tests**: 27 assertions in `ExtremeCampaignChapterTest` covering win/loss branching, full comeback arc chain, Proving Ground encounter existence, all 6 match types, and 5 featureFlag-setting choices

## Test plan
- [x] All 27 `ExtremeCampaignChapterTest` tests pass
- [x] All 12 `CampaignChapterSimulationTest` structural checks pass (routing targets valid, IDs unique, expansion codes known)
- [x] `mvn spotless:apply` applied; no formatting violations
- [x] Full test suite passes (2630+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm1r2gUBJwur4Wa1JXvQ3j