### PR TITLE
feat: add in-app direct messaging via inbox

### DIFF
--- a/src/main/java/com/github/javydreamercsw/management/config/InboxEventTypeConfig.java
+++ b/src/main/java/com/github/javydreamercsw/management/config/InboxEventTypeConfig.java
@@ -135,4 +135,9 @@ public class InboxEventTypeConfig {
   @Qualifier("UPDATE_AVAILABLE") InboxEventType updateAvailable() {
     return new InboxEventType("UPDATE_AVAILABLE", "Update Available");
   }
+
+  @Bean
+  @Qualifier("DIRECT_MESSAGE") InboxEventType directMessage() {
+    return new InboxEventType("DIRECT_MESSAGE", "Direct Message");
+  }
 }

--- a/src/main/java/com/github/javydreamercsw/management/domain/inbox/InboxItem.java
+++ b/src/main/java/com/github/javydreamercsw/management/domain/inbox/InboxItem.java
@@ -73,6 +73,9 @@ public class InboxItem extends AbstractEntity<Long> {
   @Column(name = "action_payload", length = 512)
   private String actionPayload;
 
+  @Column(name = "sender_account_id")
+  private Long senderAccountId;
+
   @OneToMany(
       mappedBy = "inboxItem",
       cascade = CascadeType.ALL,

--- a/src/main/java/com/github/javydreamercsw/management/service/inbox/DirectMessageService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/inbox/DirectMessageService.java
@@ -1,0 +1,70 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.inbox;
+
+import com.github.javydreamercsw.base.domain.account.Account;
+import com.github.javydreamercsw.base.security.CustomUserDetails;
+import com.github.javydreamercsw.base.security.SecurityUtils;
+import com.github.javydreamercsw.management.domain.inbox.InboxEventTypeRegistry;
+import com.github.javydreamercsw.management.domain.inbox.InboxItem;
+import com.github.javydreamercsw.management.domain.inbox.InboxItem.Urgency;
+import com.github.javydreamercsw.management.domain.inbox.InboxItemTarget.TargetType;
+import com.github.javydreamercsw.management.domain.inbox.InboxRepository;
+import com.github.javydreamercsw.management.event.inbox.InboxUpdateBroadcaster;
+import com.github.javydreamercsw.management.event.inbox.InboxUpdateEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DirectMessageService {
+
+  private final InboxRepository inboxRepository;
+  private final InboxEventTypeRegistry registry;
+  private final InboxUpdateBroadcaster inboxUpdateBroadcaster;
+  private final SecurityUtils securityUtils;
+
+  @PreAuthorize("isAuthenticated()")
+  public InboxItem send(final Long recipientAccountId, final String subject, final String body) {
+    Account sender =
+        securityUtils
+            .getAuthenticatedUser()
+            .map(CustomUserDetails::getAccount)
+            .orElseThrow(() -> new IllegalStateException("No authenticated user"));
+
+    InboxItem item = new InboxItem();
+    item.setSenderAccountId(sender.getId());
+    item.setEventType(
+        registry.getEventTypes().stream()
+            .filter(t -> "DIRECT_MESSAGE".equals(t.getName()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("DIRECT_MESSAGE event type not found")));
+    item.setSubject(subject);
+    item.setDescription(body);
+    item.setUrgency(Urgency.INFO);
+    item.setActionType("REPLY");
+    item.setActionPayload("{\"senderId\":\"" + sender.getId() + "\"}");
+    item.addTarget(String.valueOf(recipientAccountId), TargetType.ACCOUNT);
+
+    InboxItem saved = inboxRepository.save(item);
+    inboxUpdateBroadcaster.broadcast(new InboxUpdateEvent(this));
+    return saved;
+  }
+}

--- a/src/main/java/com/github/javydreamercsw/management/ui/view/inbox/ComposeMessageDialog.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/view/inbox/ComposeMessageDialog.java
@@ -1,0 +1,119 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.ui.view.inbox;
+
+import com.github.javydreamercsw.base.domain.account.Account;
+import com.github.javydreamercsw.base.domain.account.AccountRepository;
+import com.github.javydreamercsw.management.service.inbox.DirectMessageService;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.notification.NotificationVariant;
+import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.component.textfield.TextField;
+import java.util.List;
+
+public class ComposeMessageDialog extends Dialog {
+
+  private final ComboBox<Account> recipientPicker = new ComboBox<>("To");
+  private final TextField subjectField = new TextField("Subject");
+  private final TextArea bodyField = new TextArea("Message");
+
+  public ComposeMessageDialog(
+      final AccountRepository accountRepository,
+      final DirectMessageService directMessageService,
+      final Long senderAccountId,
+      final Long prefilledRecipientId) {
+
+    setWidth("560px");
+    setMaxWidth("95vw");
+
+    List<Account> recipients =
+        accountRepository.findAll().stream()
+            .filter(a -> !a.getId().equals(senderAccountId))
+            .sorted((a, b) -> a.getUsername().compareToIgnoreCase(b.getUsername()))
+            .toList();
+
+    recipientPicker.setItems(recipients);
+    recipientPicker.setItemLabelGenerator(Account::getUsername);
+    recipientPicker.setWidthFull();
+    recipientPicker.setRequired(true);
+
+    if (prefilledRecipientId != null) {
+      recipients.stream()
+          .filter(a -> a.getId().equals(prefilledRecipientId))
+          .findFirst()
+          .ifPresent(recipientPicker::setValue);
+    }
+
+    subjectField.setWidthFull();
+    subjectField.setMaxLength(255);
+    subjectField.setRequired(true);
+
+    bodyField.setWidthFull();
+    bodyField.setMaxLength(1024);
+    bodyField.setMinHeight("120px");
+    bodyField.setRequired(true);
+
+    Button sendBtn = new Button("Send");
+    sendBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+    sendBtn.addClickListener(
+        e -> {
+          if (!isValid()) {
+            Notification.show("Please fill in all required fields.")
+                .addThemeVariants(NotificationVariant.LUMO_ERROR);
+            return;
+          }
+          directMessageService.send(
+              recipientPicker.getValue().getId(), subjectField.getValue(), bodyField.getValue());
+          Notification.show("Message sent to " + recipientPicker.getValue().getUsername() + ".")
+              .addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+          close();
+        });
+
+    Button cancelBtn = new Button("Cancel", e -> close());
+    cancelBtn.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+
+    HorizontalLayout footer = new HorizontalLayout(sendBtn, cancelBtn);
+    footer.setAlignItems(Alignment.CENTER);
+
+    VerticalLayout content =
+        new VerticalLayout(
+            new H3("Compose Message"), recipientPicker, subjectField, bodyField, footer);
+    content.setPadding(false);
+    content.setSpacing(true);
+    add(content);
+
+    if (prefilledRecipientId != null) {
+      subjectField.focus();
+    } else {
+      recipientPicker.focus();
+    }
+  }
+
+  private boolean isValid() {
+    return recipientPicker.getValue() != null
+        && !subjectField.getValue().isBlank()
+        && !bodyField.getValue().isBlank();
+  }
+}

--- a/src/main/java/com/github/javydreamercsw/management/ui/view/inbox/InboxView.java
+++ b/src/main/java/com/github/javydreamercsw/management/ui/view/inbox/InboxView.java
@@ -24,6 +24,7 @@ import com.github.javydreamercsw.management.domain.inbox.InboxItem;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.event.inbox.OpenProfileDrawerBroadcaster;
+import com.github.javydreamercsw.management.service.inbox.DirectMessageService;
 import com.github.javydreamercsw.management.service.inbox.InboxService;
 import com.github.javydreamercsw.management.service.league.MatchFulfillmentService;
 import com.github.javydreamercsw.management.ui.view.MainLayout;
@@ -86,6 +87,7 @@ public class InboxView extends VerticalLayout {
   private final Button deleteSelectedButton = new Button("Delete Selected");
   private final Set<InboxItem> selectedItems = new HashSet<>();
   private final SecurityUtils securityUtils;
+  private final DirectMessageService directMessageService;
 
   public InboxView(
       final InboxService inboxService,
@@ -94,7 +96,8 @@ public class InboxView extends VerticalLayout {
       final MatchFulfillmentService matchFulfillmentService,
       final SecurityUtils securityUtils,
       final ObjectMapper objectMapper,
-      final OpenProfileDrawerBroadcaster openProfileDrawerBroadcaster) {
+      final OpenProfileDrawerBroadcaster openProfileDrawerBroadcaster,
+      final DirectMessageService directMessageService) {
     this.inboxService = inboxService;
     this.eventTypeRegistry = eventTypeRegistry;
     this.wrestlerRepository = wrestlerRepository;
@@ -102,6 +105,7 @@ public class InboxView extends VerticalLayout {
     this.securityUtils = securityUtils;
     this.objectMapper = objectMapper;
     this.openProfileDrawerBroadcaster = openProfileDrawerBroadcaster;
+    this.directMessageService = directMessageService;
 
     addClassName("inbox-view");
     setSizeFull();
@@ -225,8 +229,13 @@ public class InboxView extends VerticalLayout {
         });
     // Hide clear target filter button if the target filter is read-only
     clearTargetFilter.setVisible(securityUtils.canEdit() && !targetFilter.isReadOnly());
+
+    Button composeBtn = new Button("✉ Compose", e -> openComposeDialog(null));
+    composeBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY, ButtonVariant.LUMO_SMALL);
+
     HorizontalLayout toolbar =
         new HorizontalLayout(
+            composeBtn,
             targetFilter,
             clearTargetFilter,
             readStatusFilter,
@@ -283,6 +292,7 @@ public class InboxView extends VerticalLayout {
     grid.setId("inbox-grid");
     grid.addClassName("inbox-grid");
     grid.setSizeFull();
+    grid.addColumn(this::getSenderDisplay).setHeader("From").setId("from-column");
     grid.addColumn(InboxItem::getEventType).setHeader("Event Type").setId("event-type-column");
     grid.addComponentColumn(this::createUrgencyBadge)
         .setHeader("Priority")
@@ -319,6 +329,7 @@ public class InboxView extends VerticalLayout {
         case "MATCH_REPORT" -> layout.add(createMatchReportButton(item));
         case "NAVIGATE" -> createNavigateButton(item).ifPresent(layout::add);
         case "OPEN_DRAWER" -> layout.add(createOpenDrawerButton(item));
+        case "REPLY" -> layout.add(createReplyButton(item));
         default -> {
           // Unknown action type — no extra button rendered
         }
@@ -443,6 +454,40 @@ public class InboxView extends VerticalLayout {
         .collect(Collectors.joining(", "));
   }
 
+  private String getSenderDisplay(@NonNull final InboxItem item) {
+    if (item.getSenderAccountId() == null) {
+      return "System";
+    }
+    return inboxService
+        .getAccountRepository()
+        .findById(item.getSenderAccountId())
+        .map(com.github.javydreamercsw.base.domain.account.Account::getUsername)
+        .orElse("Unknown (" + item.getSenderAccountId() + ")");
+  }
+
+  private Button createReplyButton(@NonNull final InboxItem item) {
+    Button button =
+        new Button(
+            "Reply",
+            e ->
+                openComposeDialog(
+                    item.getSenderAccountId() != null ? item.getSenderAccountId() : null));
+    button.setId("reply-btn-" + item.getId());
+    button.addThemeVariants(ButtonVariant.LUMO_SMALL);
+    return button;
+  }
+
+  private void openComposeDialog(final Long prefilledRecipientId) {
+    Long senderId =
+        securityUtils.getAuthenticatedUser().map(u -> u.getAccount().getId()).orElse(null);
+    new ComposeMessageDialog(
+            inboxService.getAccountRepository(),
+            directMessageService,
+            senderId,
+            prefilledRecipientId)
+        .open();
+  }
+
   private void showEmptyDetail() {
     detailsView.removeAll();
     Paragraph empty = new Paragraph("Select a message to read it.");
@@ -475,6 +520,15 @@ public class InboxView extends VerticalLayout {
     detailsView.setPadding(true);
     detailsView.setSpacing(true);
     splitLayout.setSplitterPosition(45);
+
+    // From row — shown only for player-sent messages
+    if (item.getSenderAccountId() != null) {
+      String senderName = getSenderDisplay(item);
+      Span fromSpan = new Span("From: " + senderName);
+      fromSpan.getStyle().set("color", "var(--lumo-secondary-text-color)");
+      fromSpan.getStyle().set("font-size", "var(--lumo-font-size-s)");
+      detailsView.add(fromSpan);
+    }
 
     // Header row: event type badge + timestamp
     Span eventTypeBadge = new Span(item.getEventType().getFriendlyName());

--- a/src/main/resources/db/migration/h2/V121__add_sender_to_inbox_item.sql
+++ b/src/main/resources/db/migration/h2/V121__add_sender_to_inbox_item.sql
@@ -1,0 +1,2 @@
+ALTER TABLE inbox_item ADD COLUMN sender_account_id BIGINT NULL;
+ALTER TABLE inbox_item ADD CONSTRAINT fk_inbox_sender FOREIGN KEY (sender_account_id) REFERENCES account(id) ON DELETE SET NULL;

--- a/src/main/resources/db/migration/mysql/V90__add_sender_to_inbox_item.sql
+++ b/src/main/resources/db/migration/mysql/V90__add_sender_to_inbox_item.sql
@@ -1,0 +1,3 @@
+ALTER TABLE inbox_item
+  ADD COLUMN sender_account_id BIGINT NULL,
+  ADD CONSTRAINT fk_inbox_sender FOREIGN KEY (sender_account_id) REFERENCES account(id) ON DELETE SET NULL;

--- a/src/test/java/com/github/javydreamercsw/management/service/inbox/DirectMessageServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/inbox/DirectMessageServiceTest.java
@@ -1,0 +1,119 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.inbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.base.domain.account.Account;
+import com.github.javydreamercsw.base.security.CustomUserDetails;
+import com.github.javydreamercsw.base.security.SecurityUtils;
+import com.github.javydreamercsw.management.domain.inbox.InboxEventType;
+import com.github.javydreamercsw.management.domain.inbox.InboxEventTypeRegistry;
+import com.github.javydreamercsw.management.domain.inbox.InboxItem;
+import com.github.javydreamercsw.management.domain.inbox.InboxItem.Urgency;
+import com.github.javydreamercsw.management.domain.inbox.InboxItemTarget.TargetType;
+import com.github.javydreamercsw.management.domain.inbox.InboxRepository;
+import com.github.javydreamercsw.management.event.inbox.InboxUpdateBroadcaster;
+import com.github.javydreamercsw.management.event.inbox.InboxUpdateEvent;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DirectMessageServiceTest {
+
+  @Mock private InboxRepository inboxRepository;
+  @Mock private InboxEventTypeRegistry registry;
+  @Mock private InboxUpdateBroadcaster inboxUpdateBroadcaster;
+  @Mock private SecurityUtils securityUtils;
+
+  @InjectMocks private DirectMessageService directMessageService;
+
+  private Account senderAccount;
+  private CustomUserDetails userDetails;
+
+  @BeforeEach
+  void setUp() {
+    senderAccount = mock(Account.class);
+    when(senderAccount.getId()).thenReturn(1L);
+    userDetails = new CustomUserDetails(senderAccount, null);
+
+    InboxEventType directMessageType = new InboxEventType("DIRECT_MESSAGE", "Direct Message");
+    when(registry.getEventTypes()).thenReturn(List.of(directMessageType));
+  }
+
+  @Test
+  @DisplayName("send() saves item with correct senderAccountId, event type, and recipient target")
+  void send_savesItemWithCorrectFields() {
+    when(securityUtils.getAuthenticatedUser()).thenReturn(Optional.of(userDetails));
+    InboxItem saved = new InboxItem();
+    saved.setId(99L);
+    when(inboxRepository.save(any())).thenReturn(saved);
+
+    InboxItem result = directMessageService.send(42L, "Hello", "Body text");
+
+    ArgumentCaptor<InboxItem> captor = ArgumentCaptor.forClass(InboxItem.class);
+    verify(inboxRepository).save(captor.capture());
+    InboxItem captured = captor.getValue();
+
+    assertThat(captured.getSenderAccountId()).isEqualTo(1L);
+    assertThat(captured.getEventType().getName()).isEqualTo("DIRECT_MESSAGE");
+    assertThat(captured.getSubject()).isEqualTo("Hello");
+    assertThat(captured.getDescription()).isEqualTo("Body text");
+    assertThat(captured.getUrgency()).isEqualTo(Urgency.INFO);
+    assertThat(captured.getActionType()).isEqualTo("REPLY");
+    assertThat(captured.getTargets())
+        .anyMatch(t -> t.getTargetId().equals("42") && t.getTargetType() == TargetType.ACCOUNT);
+    assertThat(result).isEqualTo(saved);
+  }
+
+  @Test
+  @DisplayName("send() broadcasts after saving the item")
+  void send_broadcastsAfterSave() {
+    when(securityUtils.getAuthenticatedUser()).thenReturn(Optional.of(userDetails));
+    when(inboxRepository.save(any())).thenReturn(new InboxItem());
+
+    directMessageService.send(42L, "Subject", "Body");
+
+    verify(inboxUpdateBroadcaster).broadcast(any(InboxUpdateEvent.class));
+  }
+
+  @Test
+  @DisplayName("send() throws IllegalStateException when no authenticated user")
+  void send_throwsWhenNotAuthenticated() {
+    when(securityUtils.getAuthenticatedUser()).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> directMessageService.send(42L, "Subject", "Body"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("No authenticated user");
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/ui/view/inbox/ComposeMessageDialogTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/ui/view/inbox/ComposeMessageDialogTest.java
@@ -1,0 +1,123 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.ui.view.inbox;
+
+import static com.github.mvysny.kaributesting.v10.LocatorJ._click;
+import static com.github.mvysny.kaributesting.v10.LocatorJ._get;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.base.domain.account.Account;
+import com.github.javydreamercsw.base.domain.account.AccountRepository;
+import com.github.javydreamercsw.management.service.inbox.DirectMessageService;
+import com.github.javydreamercsw.management.ui.view.AbstractViewTest;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.component.textfield.TextField;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class ComposeMessageDialogTest extends AbstractViewTest {
+
+  @Mock private AccountRepository accountRepository;
+  @Mock private DirectMessageService directMessageService;
+
+  private Account alice;
+  private Account bob;
+
+  @BeforeEach
+  void setupAccounts() {
+    alice = mock(Account.class);
+    when(alice.getId()).thenReturn(1L);
+    when(alice.getUsername()).thenReturn("alice");
+
+    bob = mock(Account.class);
+    when(bob.getId()).thenReturn(2L);
+    when(bob.getUsername()).thenReturn("bob");
+
+    when(accountRepository.findAll()).thenReturn(List.of(alice, bob));
+  }
+
+  @Test
+  @DisplayName("Send button does not call service when fields are empty")
+  void send_withEmptyFields_doesNotCallService() {
+    ComposeMessageDialog dialog =
+        new ComposeMessageDialog(accountRepository, directMessageService, 99L, null);
+    dialog.open();
+
+    Button sendBtn = _get(dialog, Button.class, spec -> spec.withText("Send"));
+    _click(sendBtn);
+
+    verifyNoInteractions(directMessageService);
+  }
+
+  @Test
+  @DisplayName("Send button calls directMessageService.send() with correct arguments")
+  @SuppressWarnings("unchecked")
+  void send_withValidFields_callsService() {
+    ComposeMessageDialog dialog =
+        new ComposeMessageDialog(accountRepository, directMessageService, 99L, null);
+    dialog.open();
+
+    ComboBox<Account> recipientPicker = (ComboBox<Account>) _get(dialog, ComboBox.class);
+    recipientPicker.setValue(alice);
+
+    _get(dialog, TextField.class).setValue("Hello");
+    _get(dialog, TextArea.class).setValue("Body of message");
+
+    Button sendBtn = _get(dialog, Button.class, spec -> spec.withText("Send"));
+    _click(sendBtn);
+
+    verify(directMessageService).send(eq(1L), eq("Hello"), eq("Body of message"));
+  }
+
+  @Test
+  @DisplayName("Prefilled recipient is pre-selected when prefilledRecipientId matches an account")
+  @SuppressWarnings("unchecked")
+  void prefilledRecipient_isSelected() {
+    // sender is alice (id=1), prefilled recipient is bob (id=2)
+    ComposeMessageDialog dialog =
+        new ComposeMessageDialog(accountRepository, directMessageService, 1L, 2L);
+    dialog.open();
+
+    ComboBox<Account> recipientPicker = (ComboBox<Account>) _get(dialog, ComboBox.class);
+    assertThat(recipientPicker.getValue()).isNotNull();
+    assertThat(recipientPicker.getValue().getUsername()).isEqualTo("bob");
+  }
+
+  @Test
+  @DisplayName("Cancel button closes the dialog")
+  void cancelButton_closesDialog() {
+    ComposeMessageDialog dialog =
+        new ComposeMessageDialog(accountRepository, directMessageService, 99L, null);
+    dialog.open();
+    assertThat(dialog.isOpened()).isTrue();
+
+    Button cancelBtn = _get(dialog, Button.class, spec -> spec.withText("Cancel"));
+    _click(cancelBtn);
+
+    assertThat(dialog.isOpened()).isFalse();
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/ui/view/inbox/InboxViewE2ETest.java
+++ b/src/test/java/com/github/javydreamercsw/management/ui/view/inbox/InboxViewE2ETest.java
@@ -126,9 +126,10 @@ class InboxViewE2ETest extends AbstractE2ETest {
             ExpectedConditions.presenceOfAllElementsLocatedBy(
                 By.cssSelector("vaadin-grid > vaadin-grid-cell-content:not(:empty)")));
 
-    // 1 header row * 7 columns + 3 data rows * 7 columns = 28 cells
-    // (1 selection col + 6 data cols: eventType, urgency, subject, timestamp, targets, actions)
-    Assertions.assertEquals(28, cells.size());
+    // 1 header row * 8 columns + 3 data rows * 8 columns = 32 cells
+    // (1 selection col + 7 data cols: from, eventType, urgency, subject, timestamp, targets,
+    // actions)
+    Assertions.assertEquals(32, cells.size());
 
     // Explicitly set "Read Status" to "All" (this should already be the default, but we'll keep it
     // for robustness)

--- a/src/test/java/com/github/javydreamercsw/management/ui/view/inbox/InboxViewTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/ui/view/inbox/InboxViewTest.java
@@ -35,6 +35,7 @@ import com.github.javydreamercsw.management.domain.inbox.InboxItem;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.event.inbox.OpenProfileDrawerBroadcaster;
+import com.github.javydreamercsw.management.service.inbox.DirectMessageService;
 import com.github.javydreamercsw.management.service.inbox.InboxService;
 import com.github.javydreamercsw.management.service.league.MatchFulfillmentService;
 import com.github.javydreamercsw.management.ui.view.AbstractViewTest;
@@ -60,6 +61,7 @@ class InboxViewTest extends AbstractViewTest {
   @Mock private MatchFulfillmentService matchFulfillmentService;
   @Mock private SecurityUtils securityUtils;
   @Mock private OpenProfileDrawerBroadcaster openProfileDrawerBroadcaster;
+  @Mock private DirectMessageService directMessageService;
 
   private final ObjectMapper objectMapper = new ObjectMapper();
   private InboxView view;
@@ -79,7 +81,8 @@ class InboxViewTest extends AbstractViewTest {
             matchFulfillmentService,
             securityUtils,
             objectMapper,
-            openProfileDrawerBroadcaster);
+            openProfileDrawerBroadcaster,
+            directMessageService);
     UI.getCurrent().add(view);
   }
 
@@ -112,7 +115,8 @@ class InboxViewTest extends AbstractViewTest {
             matchFulfillmentService,
             securityUtils,
             objectMapper,
-            openProfileDrawerBroadcaster);
+            openProfileDrawerBroadcaster,
+            directMessageService);
     UI.getCurrent().add(playerView);
 
     MultiSelectComboBox<?> targetFilter = _get(playerView, MultiSelectComboBox.class);
@@ -142,7 +146,8 @@ class InboxViewTest extends AbstractViewTest {
             matchFulfillmentService,
             securityUtils,
             objectMapper,
-            openProfileDrawerBroadcaster);
+            openProfileDrawerBroadcaster,
+            directMessageService);
     UI.getCurrent().add(freshView);
 
     Button markRead = _get(freshView, Button.class, spec -> spec.withText("Mark Selected as Read"));
@@ -177,7 +182,8 @@ class InboxViewTest extends AbstractViewTest {
             matchFulfillmentService,
             securityUtils,
             objectMapper,
-            openProfileDrawerBroadcaster);
+            openProfileDrawerBroadcaster,
+            directMessageService);
     UI.getCurrent().add(freshView);
 
     Grid<InboxItem> grid = _get(freshView, Grid.class);
@@ -210,7 +216,8 @@ class InboxViewTest extends AbstractViewTest {
             matchFulfillmentService,
             securityUtils,
             objectMapper,
-            openProfileDrawerBroadcaster);
+            openProfileDrawerBroadcaster,
+            directMessageService);
     UI.getCurrent().add(freshView);
 
     Grid<InboxItem> grid = _get(freshView, Grid.class);
@@ -242,7 +249,8 @@ class InboxViewTest extends AbstractViewTest {
             matchFulfillmentService,
             securityUtils,
             objectMapper,
-            openProfileDrawerBroadcaster);
+            openProfileDrawerBroadcaster,
+            directMessageService);
     UI.getCurrent().add(freshView);
 
     Grid<InboxItem> grid = _get(freshView, Grid.class);
@@ -279,7 +287,8 @@ class InboxViewTest extends AbstractViewTest {
             matchFulfillmentService,
             securityUtils,
             objectMapper,
-            openProfileDrawerBroadcaster);
+            openProfileDrawerBroadcaster,
+            directMessageService);
     UI.getCurrent().add(freshView);
 
     Grid<InboxItem> grid = _get(freshView, Grid.class);
@@ -315,7 +324,8 @@ class InboxViewTest extends AbstractViewTest {
             matchFulfillmentService,
             securityUtils,
             objectMapper,
-            openProfileDrawerBroadcaster);
+            openProfileDrawerBroadcaster,
+            directMessageService);
     UI.getCurrent().add(freshView);
 
     Grid<InboxItem> grid = _get(freshView, Grid.class);

--- a/src/test/java/com/github/javydreamercsw/management/ui/view/inbox/InboxViewTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/ui/view/inbox/InboxViewTest.java
@@ -16,6 +16,7 @@
 */
 package com.github.javydreamercsw.management.ui.view.inbox;
 
+import static com.github.mvysny.kaributesting.v10.LocatorJ._find;
 import static com.github.mvysny.kaributesting.v10.LocatorJ._get;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -27,6 +28,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javydreamercsw.base.domain.account.Account;
+import com.github.javydreamercsw.base.domain.account.AccountRepository;
 import com.github.javydreamercsw.base.security.CustomUserDetails;
 import com.github.javydreamercsw.base.security.SecurityUtils;
 import com.github.javydreamercsw.management.domain.inbox.InboxEventType;
@@ -44,6 +46,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Span;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -62,6 +65,7 @@ class InboxViewTest extends AbstractViewTest {
   @Mock private SecurityUtils securityUtils;
   @Mock private OpenProfileDrawerBroadcaster openProfileDrawerBroadcaster;
   @Mock private DirectMessageService directMessageService;
+  @Mock private AccountRepository accountRepository;
 
   private final ObjectMapper objectMapper = new ObjectMapper();
   private InboxView view;
@@ -332,5 +336,123 @@ class InboxViewTest extends AbstractViewTest {
     GridKt._clickItem(grid, 0, 1, false, false, false, false);
 
     org.mockito.Mockito.verifyNoMoreInteractions(org.mockito.Mockito.ignoreStubs(inboxService));
+  }
+
+  @Test
+  @DisplayName("Compose button is present in the toolbar")
+  void composeButton_isPresentInToolbar() {
+    Button composeBtn = _get(view, Button.class, spec -> spec.withText("✉ Compose"));
+    assertTrue(composeBtn.isVisible());
+  }
+
+  @Test
+  @DisplayName("REPLY action type renders a reply button in the detail pane")
+  void createActionComponent_reply_rendersReplyButton() {
+    InboxEventType eventType = new InboxEventType("DIRECT_MESSAGE", "Direct Message");
+    InboxItem item = new InboxItem();
+    item.setId(50L);
+    item.setEventType(eventType);
+    item.setRead(true);
+    item.setDescription("A direct message");
+    item.setActionType("REPLY");
+
+    when(inboxService.search(any(), any(), any(), any(), any())).thenReturn(List.of(item));
+    when(inboxService.getAccountRepository()).thenReturn(accountRepository);
+    when(accountRepository.findById(any())).thenReturn(Optional.empty());
+
+    InboxView freshView =
+        new InboxView(
+            inboxService,
+            eventTypeRegistry,
+            wrestlerRepository,
+            matchFulfillmentService,
+            securityUtils,
+            objectMapper,
+            openProfileDrawerBroadcaster,
+            directMessageService);
+    UI.getCurrent().add(freshView);
+
+    Grid<InboxItem> grid = _get(freshView, Grid.class);
+    GridKt._clickItem(grid, 0, 1, false, false, false, false);
+
+    Button replyBtn = _get(freshView, Button.class, spec -> spec.withId("reply-btn-50"));
+    assertThat(replyBtn.getText()).isEqualTo("Reply");
+  }
+
+  @Test
+  @DisplayName("showDetails renders From: span when senderAccountId is set")
+  void showDetails_withSenderAccountId_rendersFromSpan() {
+    InboxEventType eventType = new InboxEventType("DIRECT_MESSAGE", "Direct Message");
+    InboxItem item = new InboxItem();
+    item.setId(60L);
+    item.setEventType(eventType);
+    item.setRead(true);
+    item.setDescription("Direct message body");
+    item.setSenderAccountId(5L);
+
+    Account sender = mock(Account.class);
+    when(sender.getUsername()).thenReturn("alice");
+    when(inboxService.getAccountRepository()).thenReturn(accountRepository);
+    when(accountRepository.findById(5L)).thenReturn(Optional.of(sender));
+    when(inboxService.search(any(), any(), any(), any(), any())).thenReturn(List.of(item));
+
+    InboxView freshView =
+        new InboxView(
+            inboxService,
+            eventTypeRegistry,
+            wrestlerRepository,
+            matchFulfillmentService,
+            securityUtils,
+            objectMapper,
+            openProfileDrawerBroadcaster,
+            directMessageService);
+    UI.getCurrent().add(freshView);
+
+    Grid<InboxItem> grid = _get(freshView, Grid.class);
+    GridKt._clickItem(grid, 0, 1, false, false, false, false);
+
+    List<Span> fromSpans =
+        _find(
+            freshView,
+            Span.class,
+            spec -> spec.withPredicate(s -> s.getText().startsWith("From:")));
+    assertThat(fromSpans).hasSize(1);
+    assertThat(fromSpans.get(0).getText()).isEqualTo("From: alice");
+  }
+
+  @Test
+  @DisplayName("showDetails omits From: span when senderAccountId is null")
+  void showDetails_withoutSenderAccountId_noFromSpan() {
+    InboxEventType eventType = new InboxEventType("MATCH_REQUEST", "Match Request");
+    InboxItem item = new InboxItem();
+    item.setId(70L);
+    item.setEventType(eventType);
+    item.setRead(true);
+    item.setDescription("System generated message");
+
+    when(inboxService.search(any(), any(), any(), any(), any())).thenReturn(List.of(item));
+    when(inboxService.getAccountRepository()).thenReturn(accountRepository);
+
+    InboxView freshView =
+        new InboxView(
+            inboxService,
+            eventTypeRegistry,
+            wrestlerRepository,
+            matchFulfillmentService,
+            securityUtils,
+            objectMapper,
+            openProfileDrawerBroadcaster,
+            directMessageService);
+    UI.getCurrent().add(freshView);
+
+    Grid<InboxItem> grid = _get(freshView, Grid.class);
+    GridKt._clickItem(grid, 0, 1, false, false, false, false);
+
+    List<Span> fromSpans =
+        _find(
+            freshView,
+            Span.class,
+            spec -> spec.withPredicate(s -> s.getText().startsWith("From:")));
+    assertThat(fromSpans).isEmpty();
   }
 }


### PR DESCRIPTION
- Add sender_account_id FK column to inbox_item (H2 V121, MySQL V90)
- Register DIRECT_MESSAGE event type in InboxEventTypeConfig
- Add DirectMessageService with @PreAuthorize("isAuthenticated()") that saves messages directly via InboxRepository and broadcasts via InboxUpdateBroadcaster
- Add ComposeMessageDialog (recipient picker, subject, body, reply support)
- Enhance InboxView with Compose button, From column, Reply action, and sender attribution in the detail pane
- Fix InboxViewTest to pass DirectMessageService as 8th constructor arg