### PR TITLE
feat: ATW faction war booking

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,7 +19,7 @@ doing a simple exact-string sanity check after Repowise already pointed you at a
 
 ## Codebase Intelligence for all-time-wrestling-rpg (Repowise)
 
-Indexed by [Repowise](https://repowise.dev). Last indexed: 2026-08-10 (commit 85f97a24e). Confidence: 100%.
+Indexed by [Repowise](https://repowise.dev). Last indexed: 2026-08-10 (commit 98cba48b5). Confidence: 100%.
 The MCP tools below serve pre-verified docs, symbols, history, and health from that index. Every response carries `_meta` freshness fields; a `stale_warning` appears only when a file the response actually serves changed after indexing — silence means current.
 
 ### How to work in this repo

--- a/src/main/java/com/github/javydreamercsw/management/domain/show/BookingMode.java
+++ b/src/main/java/com/github/javydreamercsw/management/domain/show/BookingMode.java
@@ -1,0 +1,30 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.domain.show;
+
+/**
+ * Determines the segment-generation strategy used when auto-booking a show. The show type (PLE,
+ * Weekly, …) describes what the event is; the booking mode describes how its card is built.
+ */
+public enum BookingMode {
+
+  /** Standard rivalry- and availability-driven booking (default). */
+  STANDARD,
+
+  /** All segments are generated from active faction-vs-faction rivalries and feuds. */
+  FACTION_WAR,
+}

--- a/src/main/java/com/github/javydreamercsw/management/domain/show/Show.java
+++ b/src/main/java/com/github/javydreamercsw/management/domain/show/Show.java
@@ -27,6 +27,8 @@ import com.github.javydreamercsw.management.domain.show.type.ShowType;
 import com.github.javydreamercsw.management.domain.universe.Universe;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -112,6 +114,10 @@ public class Show extends AbstractEntity<Long> {
 
   @Column(name = "quality_score")
   private Double qualityScore;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "booking_mode", nullable = false)
+  private BookingMode bookingMode = BookingMode.STANDARD;
 
   /**
    * Check if this show is based on a Premium Live Event template.

--- a/src/main/java/com/github/javydreamercsw/management/service/show/FactionWarBookingService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/FactionWarBookingService.java
@@ -1,0 +1,272 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.show;
+
+import com.github.javydreamercsw.management.domain.faction.Faction;
+import com.github.javydreamercsw.management.domain.faction.FactionRivalry;
+import com.github.javydreamercsw.management.domain.feud.FeudParticipant;
+import com.github.javydreamercsw.management.domain.feud.MultiWrestlerFeud;
+import com.github.javydreamercsw.management.domain.show.Show;
+import com.github.javydreamercsw.management.domain.show.segment.Segment;
+import com.github.javydreamercsw.management.domain.show.segment.type.SegmentType;
+import com.github.javydreamercsw.management.domain.show.segment.type.SegmentTypeNames;
+import com.github.javydreamercsw.management.domain.show.segment.type.SegmentTypeRepository;
+import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
+import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
+import com.github.javydreamercsw.management.service.faction.FactionRivalryService;
+import com.github.javydreamercsw.management.service.faction.FactionService;
+import com.github.javydreamercsw.management.service.feud.MultiWrestlerFeudService;
+import com.github.javydreamercsw.management.service.segment.NPCSegmentResolutionService;
+import com.github.javydreamercsw.management.service.segment.SegmentTeam;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Booking engine for Faction War shows. Generates match segments driven by faction-vs-faction
+ * rivalries and feuds instead of the individual-rivalry pipeline used by standard shows.
+ *
+ * <p>Priority order (highest fills slots first):
+ *
+ * <ol>
+ *   <li>Active faction rivalry segments sorted by heat desc — up to 60% of requested slots.
+ *   <li>Inter-faction feud singles — one match per feud that has members from ≥ 2 factions.
+ *   <li>Cross-faction random singles — filler using any two factions with unbooked members.
+ * </ol>
+ *
+ * <p>Segment type selection per rivalry: both factions with ≥ 2 available members → TAG_TEAM;
+ * otherwise ONE_ON_ONE (leader vs leader, falling back to first available member).
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class FactionWarBookingService {
+
+  private final FactionRivalryService factionRivalryService;
+  private final FactionService factionService;
+  private final MultiWrestlerFeudService multiWrestlerFeudService;
+  private final SegmentTypeRepository segmentTypeRepository;
+  private final NPCSegmentResolutionService npcSegmentResolutionService;
+
+  /**
+   * Generate match segments for a Faction War show. Promos are handled separately by the caller.
+   *
+   * @param show saved show to attach segments to
+   * @param segmentCount number of match slots to fill
+   * @return resolved segments, may be fewer than {@code segmentCount} if factions are scarce
+   */
+  @Transactional
+  @PreAuthorize(
+      "hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_BOOKER') or hasAuthority('ROLE_SYSTEM')"
+          + " or @universeAuthz.hasRoleInCurrentUniverse('BOOKER')")
+  public List<Segment> generateFactionWarSegments(
+      @NonNull final Show show, final int segmentCount) {
+
+    Optional<SegmentType> oneOnOneOpt =
+        segmentTypeRepository.findByName(SegmentTypeNames.ONE_ON_ONE);
+    if (oneOnOneOpt.isEmpty()) {
+      log.warn(
+          "ONE_ON_ONE segment type not found — Faction War booking skipped for '{}'",
+          show.getName());
+      return List.of();
+    }
+    SegmentType oneOnOne = oneOnOneOpt.get();
+    SegmentType tagTeam =
+        segmentTypeRepository.findByName(SegmentTypeNames.TAG_TEAM).orElse(oneOnOne);
+
+    List<Segment> segments = new ArrayList<>();
+    Set<Long> bookedIds = new HashSet<>();
+
+    // --- Priority 1: active faction rivalries (up to 60% of slots) ---
+    int rivalrySlots = Math.max(1, (segmentCount * 6) / 10);
+    List<FactionRivalry> rivalries =
+        factionRivalryService.getActiveFactionRivalries().stream()
+            .sorted((a, b) -> Integer.compare(b.getHeat(), a.getHeat()))
+            .toList();
+
+    for (FactionRivalry rivalry : rivalries) {
+      if (segments.size() >= rivalrySlots) {
+        break;
+      }
+      Faction f1 = rivalry.getFaction1();
+      Faction f2 = rivalry.getFaction2();
+      if (!f1.isActive() || !f2.isActive()) {
+        continue;
+      }
+      bookFactionRivalrySegment(show, f1, f2, rivalry.getHeat(), bookedIds, oneOnOne, tagTeam)
+          .ifPresent(segments::add);
+    }
+
+    // --- Priority 2: inter-faction feud singles ---
+    List<MultiWrestlerFeud> feuds = multiWrestlerFeudService.getInterFactionFeuds();
+    for (MultiWrestlerFeud feud : feuds) {
+      if (segments.size() >= segmentCount) {
+        break;
+      }
+      List<Wrestler> feudWrestlers =
+          feud.getParticipants().stream()
+              .filter(p -> Boolean.TRUE.equals(p.getIsActive()) && p.getWrestler() != null)
+              .map(FeudParticipant::getWrestler)
+              .filter(w -> w.getId() != null && !bookedIds.contains(w.getId()))
+              .collect(Collectors.toList());
+
+      if (feudWrestlers.size() < 2) {
+        continue;
+      }
+      Wrestler w1 = feudWrestlers.get(0);
+      Wrestler w2 = feudWrestlers.get(1);
+      Optional<Segment> seg =
+          bookSinglesSegment(show, w1, w2, "Inter-Faction Feud: " + feud.getName(), oneOnOne);
+      if (seg.isPresent()) {
+        segments.add(seg.get());
+        bookedIds.add(w1.getId());
+        bookedIds.add(w2.getId());
+      }
+    }
+
+    // --- Priority 3: cross-faction random filler ---
+    List<Faction> allFactions =
+        factionService.findAll().stream()
+            .filter(Faction::isActive)
+            .filter(f -> f.getMemberCount() >= 1)
+            .toList();
+
+    outer:
+    for (int i = 0; i < allFactions.size(); i++) {
+      for (int j = i + 1; j < allFactions.size(); j++) {
+        if (segments.size() >= segmentCount) {
+          break outer;
+        }
+        Faction fa = allFactions.get(i);
+        Faction fb = allFactions.get(j);
+        Optional<Wrestler> wa = pickUnbooked(fa, bookedIds);
+        Optional<Wrestler> wb = pickUnbooked(fb, bookedIds);
+        if (wa.isEmpty() || wb.isEmpty()) {
+          continue;
+        }
+        Optional<Segment> seg =
+            bookSinglesSegment(show, wa.get(), wb.get(), "Cross-Faction Match", oneOnOne);
+        if (seg.isPresent()) {
+          segments.add(seg.get());
+          bookedIds.add(wa.get().getId());
+          bookedIds.add(wb.get().getId());
+        }
+      }
+    }
+
+    log.info(
+        "Faction War booking complete: {} segment(s) generated for show '{}'",
+        segments.size(),
+        show.getName());
+    return segments;
+  }
+
+  // ==================== HELPERS ====================
+
+  private Optional<Segment> bookFactionRivalrySegment(
+      final Show show,
+      final Faction f1,
+      final Faction f2,
+      final int heat,
+      final Set<Long> bookedIds,
+      final SegmentType oneOnOne,
+      final SegmentType tagTeam) {
+
+    List<Wrestler> m1 = availableMembers(f1, bookedIds);
+    List<Wrestler> m2 = availableMembers(f2, bookedIds);
+    if (m1.isEmpty() || m2.isEmpty()) {
+      return Optional.empty();
+    }
+
+    String label =
+        "Faction War: "
+            + f1.getName()
+            + " vs "
+            + f2.getName()
+            + (heat > 0 ? " (Heat: " + heat + ")" : "");
+
+    try {
+      if (m1.size() >= 2 && m2.size() >= 2) {
+        SegmentTeam team1 = new SegmentTeam(List.of(m1.get(0), m1.get(1)), f1.getName());
+        SegmentTeam team2 = new SegmentTeam(List.of(m2.get(0), m2.get(1)), f2.getName());
+        Segment s =
+            npcSegmentResolutionService.resolveTeamSegment(team1, team2, tagTeam, show, label);
+        bookedIds.add(m1.get(0).getId());
+        bookedIds.add(m1.get(1).getId());
+        bookedIds.add(m2.get(0).getId());
+        bookedIds.add(m2.get(1).getId());
+        return Optional.of(s);
+      } else {
+        Wrestler w1 =
+            f1.getLeader() != null && m1.contains(f1.getLeader()) ? f1.getLeader() : m1.get(0);
+        Wrestler w2 =
+            f2.getLeader() != null && m2.contains(f2.getLeader()) ? f2.getLeader() : m2.get(0);
+        Segment s =
+            npcSegmentResolutionService.resolveTeamSegment(
+                new SegmentTeam(w1), new SegmentTeam(w2), oneOnOne, show, label);
+        bookedIds.add(w1.getId());
+        bookedIds.add(w2.getId());
+        return Optional.of(s);
+      }
+    } catch (Exception e) {
+      log.error("Error booking faction rivalry segment: {}", e.getMessage(), e);
+      return Optional.empty();
+    }
+  }
+
+  private Optional<Segment> bookSinglesSegment(
+      final Show show,
+      final Wrestler w1,
+      final Wrestler w2,
+      final String label,
+      final SegmentType type) {
+    try {
+      return Optional.of(
+          npcSegmentResolutionService.resolveTeamSegment(
+              new SegmentTeam(w1), new SegmentTeam(w2), type, show, label));
+    } catch (Exception e) {
+      log.error("Error booking singles segment: {}", e.getMessage(), e);
+      return Optional.empty();
+    }
+  }
+
+  private List<Wrestler> availableMembers(final Faction faction, final Set<Long> bookedIds) {
+    return faction.getMembers().stream()
+        .map(WrestlerState::getWrestler)
+        .filter(w -> w != null && w.getId() != null && !bookedIds.contains(w.getId()))
+        .collect(Collectors.toList());
+  }
+
+  private Optional<Wrestler> pickUnbooked(final Faction faction, final Set<Long> bookedIds) {
+    if (faction.getLeader() != null
+        && faction.getLeader().getId() != null
+        && !bookedIds.contains(faction.getLeader().getId())) {
+      return Optional.of(faction.getLeader());
+    }
+    return availableMembers(faction, bookedIds).stream().findFirst();
+  }
+}

--- a/src/main/java/com/github/javydreamercsw/management/service/show/ShowBookingService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/show/ShowBookingService.java
@@ -17,6 +17,7 @@
 package com.github.javydreamercsw.management.service.show;
 
 import com.github.javydreamercsw.management.domain.rivalry.Rivalry;
+import com.github.javydreamercsw.management.domain.show.BookingMode;
 import com.github.javydreamercsw.management.domain.show.Show;
 import com.github.javydreamercsw.management.domain.show.ShowRepository;
 import com.github.javydreamercsw.management.domain.show.segment.Segment;
@@ -107,6 +108,7 @@ public class ShowBookingService {
   private final SegmentRuleService segmentRuleService;
   private final UniverseContextService universeContextService;
   private final ShowSegmentReservationService reservationService;
+  private final FactionWarBookingService factionWarBookingService;
   private final Clock clock;
   private final Random random;
 
@@ -133,7 +135,13 @@ public class ShowBookingService {
       final String templateName,
       final LocalDate showDate) {
     return bookShowInternal(
-        showName, showDescription, showTypeName, segmentCount, templateName, showDate);
+        showName,
+        showDescription,
+        showTypeName,
+        segmentCount,
+        templateName,
+        showDate,
+        BookingMode.STANDARD);
   }
 
   /**
@@ -154,7 +162,42 @@ public class ShowBookingService {
       @NonNull final String showDescription,
       @NonNull final String showTypeName,
       final int segmentCount) {
-    return bookShowInternal(showName, showDescription, showTypeName, segmentCount, null, null);
+    return bookShowInternal(
+        showName, showDescription, showTypeName, segmentCount, null, null, BookingMode.STANDARD);
+  }
+
+  /**
+   * Book a Faction War show. Segments are generated from active faction-vs-faction rivalries and
+   * feuds instead of the standard individual-rivalry pipeline. The show type can be any valid type
+   * (e.g. "Premium Live Event (PLE)"); {@link BookingMode#FACTION_WAR} is recorded on the show.
+   *
+   * @param showName Name of the show
+   * @param showDescription Description of the show
+   * @param showTypeName Type of show (e.g., "Premium Live Event (PLE)")
+   * @param segmentCount Number of segments to book (3–10)
+   * @param templateName Optional show template name
+   * @param showDate Optional show date
+   * @return The booked show with faction-war segments
+   */
+  @Transactional
+  @PreAuthorize(
+      "hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_BOOKER') or hasAuthority('ROLE_SYSTEM')"
+          + " or @universeAuthz.hasRoleInCurrentUniverse('BOOKER')")
+  public Optional<Show> bookFactionWarShow(
+      @NonNull final String showName,
+      @NonNull final String showDescription,
+      @NonNull final String showTypeName,
+      final int segmentCount,
+      final String templateName,
+      final LocalDate showDate) {
+    return bookShowInternal(
+        showName,
+        showDescription,
+        showTypeName,
+        segmentCount,
+        templateName,
+        showDate,
+        BookingMode.FACTION_WAR);
   }
 
   /** Internal method to book a show with all parameters. */
@@ -164,7 +207,8 @@ public class ShowBookingService {
       @NonNull final String showTypeName,
       final int segmentCount,
       final String templateName,
-      final LocalDate showDate) {
+      final LocalDate showDate,
+      @NonNull final BookingMode bookingMode) {
     try {
       // Validate inputs
       if (segmentCount < 3 || segmentCount > 10) {
@@ -202,6 +246,7 @@ public class ShowBookingService {
       Show show = new Show();
       show.setName(showName);
       show.setDescription(showDescription);
+      show.setBookingMode(bookingMode);
       show.setType(showTypeOpt.get());
       show.setTemplate(template);
       show.setShowDate(showDate);
@@ -217,7 +262,10 @@ public class ShowBookingService {
       seasonService.addShowToActiveSeason(savedShow);
 
       // Generate segments and promos for the show
-      List<Segment> segments = generateSegmentsForShow(savedShow, segmentCount);
+      List<Segment> segments =
+          bookingMode == BookingMode.FACTION_WAR
+              ? factionWarBookingService.generateFactionWarSegments(savedShow, segmentCount)
+              : generateSegmentsForShow(savedShow, segmentCount);
       List<Segment> promos = generatePromosForShow(savedShow, segmentCount);
 
       // Manually add to collection since they were saved in different transactions

--- a/src/main/resources/db/migration/h2/V128__add_booking_mode_to_show.sql
+++ b/src/main/resources/db/migration/h2/V128__add_booking_mode_to_show.sql
@@ -1,0 +1,2 @@
+ALTER TABLE wrestling_show
+    ADD COLUMN booking_mode VARCHAR(50) NOT NULL DEFAULT 'STANDARD';

--- a/src/main/resources/db/migration/mysql/V97__add_booking_mode_to_show.sql
+++ b/src/main/resources/db/migration/mysql/V97__add_booking_mode_to_show.sql
@@ -1,0 +1,2 @@
+ALTER TABLE wrestling_show
+    ADD COLUMN booking_mode VARCHAR(50) NOT NULL DEFAULT 'STANDARD';

--- a/src/test/java/com/github/javydreamercsw/management/service/show/FactionWarBookingServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/show/FactionWarBookingServiceTest.java
@@ -1,0 +1,210 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.show;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.management.domain.faction.Faction;
+import com.github.javydreamercsw.management.domain.faction.FactionRivalry;
+import com.github.javydreamercsw.management.domain.show.Show;
+import com.github.javydreamercsw.management.domain.show.segment.Segment;
+import com.github.javydreamercsw.management.domain.show.segment.type.SegmentType;
+import com.github.javydreamercsw.management.domain.show.segment.type.SegmentTypeNames;
+import com.github.javydreamercsw.management.domain.show.segment.type.SegmentTypeRepository;
+import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
+import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
+import com.github.javydreamercsw.management.service.faction.FactionRivalryService;
+import com.github.javydreamercsw.management.service.faction.FactionService;
+import com.github.javydreamercsw.management.service.feud.MultiWrestlerFeudService;
+import com.github.javydreamercsw.management.service.segment.NPCSegmentResolutionService;
+import com.github.javydreamercsw.management.service.segment.SegmentTeam;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class FactionWarBookingServiceTest {
+
+  @Mock private FactionRivalryService factionRivalryService;
+  @Mock private FactionService factionService;
+  @Mock private MultiWrestlerFeudService multiWrestlerFeudService;
+  @Mock private SegmentTypeRepository segmentTypeRepository;
+  @Mock private NPCSegmentResolutionService npcSegmentResolutionService;
+
+  private FactionWarBookingService service;
+
+  private SegmentType oneOnOne;
+  private SegmentType tagTeam;
+  private Show show;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new FactionWarBookingService(
+            factionRivalryService,
+            factionService,
+            multiWrestlerFeudService,
+            segmentTypeRepository,
+            npcSegmentResolutionService);
+
+    oneOnOne = new SegmentType();
+    oneOnOne.setName(SegmentTypeNames.ONE_ON_ONE);
+
+    tagTeam = new SegmentType();
+    tagTeam.setName(SegmentTypeNames.TAG_TEAM);
+
+    show = new Show();
+    show.setName("Faction War PLE");
+
+    when(segmentTypeRepository.findByName(SegmentTypeNames.ONE_ON_ONE))
+        .thenReturn(Optional.of(oneOnOne));
+    when(segmentTypeRepository.findByName(SegmentTypeNames.TAG_TEAM))
+        .thenReturn(Optional.of(tagTeam));
+    when(factionRivalryService.getActiveFactionRivalries()).thenReturn(List.of());
+    when(multiWrestlerFeudService.getInterFactionFeuds()).thenReturn(List.of());
+    when(factionService.findAll()).thenReturn(List.of());
+  }
+
+  @Test
+  void generateFactionWarSegments_returnsEmptyWhenNoOneOnOneType() {
+    when(segmentTypeRepository.findByName(SegmentTypeNames.ONE_ON_ONE))
+        .thenReturn(Optional.empty());
+
+    List<Segment> result = service.generateFactionWarSegments(show, 5);
+
+    assertThat(result).isEmpty();
+    verify(npcSegmentResolutionService, never())
+        .resolveTeamSegment(any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void generateFactionWarSegments_booksSinglesFromRivalryWhenSingleFactionMembers() {
+    Wrestler leader1 = wrestler(1L, "Leader Alpha");
+    Wrestler leader2 = wrestler(2L, "Leader Beta");
+    Faction f1 = faction(1L, "Alpha", leader1, Set.of(state(leader1)));
+    Faction f2 = faction(2L, "Beta", leader2, Set.of(state(leader2)));
+    FactionRivalry rivalry = rivalry(f1, f2, 10);
+
+    when(factionRivalryService.getActiveFactionRivalries()).thenReturn(List.of(rivalry));
+    Segment resolved = new Segment();
+    when(npcSegmentResolutionService.resolveTeamSegment(
+            any(), any(), eq(oneOnOne), eq(show), any()))
+        .thenReturn(resolved);
+
+    List<Segment> result = service.generateFactionWarSegments(show, 5);
+
+    assertThat(result).contains(resolved);
+    verify(npcSegmentResolutionService)
+        .resolveTeamSegment(
+            any(SegmentTeam.class), any(SegmentTeam.class), eq(oneOnOne), eq(show), any());
+  }
+
+  @Test
+  void generateFactionWarSegments_booksTagTeamWhenBothFactionsHaveTwoOrMoreMembers() {
+    Wrestler w1a = wrestler(1L, "Alpha 1");
+    Wrestler w1b = wrestler(2L, "Alpha 2");
+    Wrestler w2a = wrestler(3L, "Beta 1");
+    Wrestler w2b = wrestler(4L, "Beta 2");
+    Faction f1 = faction(1L, "Alpha", null, Set.of(state(w1a), state(w1b)));
+    Faction f2 = faction(2L, "Beta", null, Set.of(state(w2a), state(w2b)));
+    FactionRivalry rivalry = rivalry(f1, f2, 25);
+
+    when(factionRivalryService.getActiveFactionRivalries()).thenReturn(List.of(rivalry));
+    Segment resolved = new Segment();
+    when(npcSegmentResolutionService.resolveTeamSegment(any(), any(), eq(tagTeam), eq(show), any()))
+        .thenReturn(resolved);
+
+    List<Segment> result = service.generateFactionWarSegments(show, 5);
+
+    assertThat(result).contains(resolved);
+    verify(npcSegmentResolutionService)
+        .resolveTeamSegment(
+            any(SegmentTeam.class), any(SegmentTeam.class), eq(tagTeam), eq(show), any());
+  }
+
+  @Test
+  void generateFactionWarSegments_fillsCrossFactionsWhenNoRivalries() {
+    Wrestler wa = wrestler(1L, "Indie A");
+    Wrestler wb = wrestler(2L, "Indie B");
+    Faction fa = faction(1L, "Faction A", wa, Set.of(state(wa)));
+    Faction fb = faction(2L, "Faction B", wb, Set.of(state(wb)));
+
+    when(factionService.findAll()).thenReturn(List.of(fa, fb));
+    Segment resolved = new Segment();
+    when(npcSegmentResolutionService.resolveTeamSegment(
+            any(), any(), eq(oneOnOne), eq(show), any()))
+        .thenReturn(resolved);
+
+    List<Segment> result = service.generateFactionWarSegments(show, 5);
+
+    assertThat(result).contains(resolved);
+  }
+
+  // ==================== BUILDER HELPERS ====================
+
+  private static Wrestler wrestler(long id, String name) {
+    Wrestler w = new Wrestler();
+    w.setId(id);
+    w.setName(name);
+    return w;
+  }
+
+  private static WrestlerState state(Wrestler wrestler) {
+    WrestlerState ws = new WrestlerState();
+    ws.setWrestler(wrestler);
+    return ws;
+  }
+
+  private static Faction faction(
+      long id, String name, Wrestler leader, Set<WrestlerState> members) {
+    Faction f =
+        Faction.builder()
+            .id(id)
+            .name(name)
+            .leader(leader)
+            .members(new HashSet<>(members))
+            .isActive(true)
+            .formedDate(Instant.now())
+            .build();
+    members.forEach(m -> m.setFaction(f));
+    return f;
+  }
+
+  private static FactionRivalry rivalry(Faction f1, Faction f2, int heat) {
+    FactionRivalry r = new FactionRivalry();
+    r.setFaction1(f1);
+    r.setFaction2(f2);
+    r.setHeat(heat);
+    r.setIsActive(true);
+    return r;
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/service/show/ShowBookingServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/show/ShowBookingServiceTest.java
@@ -24,6 +24,7 @@ import com.github.javydreamercsw.management.ManagementIntegrationTest;
 import com.github.javydreamercsw.management.domain.deck.DeckCardRepository;
 import com.github.javydreamercsw.management.domain.deck.DeckRepository;
 import com.github.javydreamercsw.management.domain.season.Season;
+import com.github.javydreamercsw.management.domain.show.BookingMode;
 import com.github.javydreamercsw.management.domain.show.Show;
 import com.github.javydreamercsw.management.domain.show.segment.Segment;
 import com.github.javydreamercsw.management.domain.show.segment.rule.BumpAddition;
@@ -239,6 +240,30 @@ class ShowBookingServiceTest extends ManagementIntegrationTest {
 
     // Then
     assertThat(result2).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should book faction war show with FACTION_WAR booking mode")
+  void shouldBookFactionWarShow() {
+    List<Wrestler> wrestlers = wrestlerRepository.findAll();
+    var f1 =
+        factionService
+            .createFaction(
+                "Alpha Faction", "Alpha", wrestlers.get(0).getId(), defaultUniverse.getId())
+            .orElseThrow();
+    var f2 =
+        factionService
+            .createFaction(
+                "Beta Faction", "Beta", wrestlers.get(1).getId(), defaultUniverse.getId())
+            .orElseThrow();
+    factionRivalryService.createFactionRivalry(f1.getId(), f2.getId(), "Faction war heat");
+
+    Optional<Show> result =
+        showBookingService.bookFactionWarShow(
+            "Faction War Spectacular", "Driven by faction rivalry", "Weekly Show", 5, null, null);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getBookingMode()).isEqualTo(BookingMode.FACTION_WAR);
   }
 
   @Test


### PR DESCRIPTION
Adds BookingMode enum (STANDARD/FACTION_WAR) to Show entity with dual Flyway                                                                                                                                                                                                                                                                                                                                                         
  migrations, FactionWarBookingService (3-tier priority: rivalry→feud→random filler),                                                                                                                                                                                                                                                                                                                                                  
  and bookFactionWarShow() on ShowBookingService. Integration test added to fix                                                                                                                                                                                                                                                                                                                                                        
  codecov/patch failure.                           