### PR TITLE
feat(ATW-6o99): heat event cleanup for closed rivalries

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,7 +19,7 @@ doing a simple exact-string sanity check after Repowise already pointed you at a
 
 ## Codebase Intelligence for all-time-wrestling-rpg (Repowise)
 
-Indexed by [Repowise](https://repowise.dev). Last indexed: 2026-08-11 (commit 0c76b3ad6). Confidence: 100%.
+Indexed by [Repowise](https://repowise.dev). Last indexed: 2026-08-11 (commit 65f271ac8). Confidence: 100%.
 The MCP tools below serve pre-verified docs, symbols, history, and health from that index. Every response carries `_meta` freshness fields; a `stale_warning` appears only when a file the response actually serves changed after indexing — silence means current.
 
 ### How to work in this repo
@@ -83,7 +83,7 @@ repo is a comprehensive wrestling promotion management platform that consumes us
 
 ### Code health
 
-Three co-equal signals: defect risk 8.25/10 avg, hotspot health 5.6/10 (stable), worst `src/main/java/com/github/javydreamercsw/management/service/campaign/CampaignChapterService.java` at 1.0/10 · maintainability 8.86/10 · performance risk 267 open static I/O-in-loop / N+1 findings. Detail: `get_health()`.
+Three co-equal signals: defect risk 8.26/10 avg, hotspot health 5.62/10 (stable), worst `src/main/java/com/github/javydreamercsw/management/service/campaign/CampaignChapterService.java` at 1.0/10 · maintainability 8.86/10 · performance risk 267 open static I/O-in-loop / N+1 findings. Detail: `get_health()`.
 
 Critical files:
 - `src/main/java/com/github/javydreamercsw/management/service/campaign/PlaceholderResolverService.java` — change entropy — impact −3.0

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,7 +19,7 @@ doing a simple exact-string sanity check after Repowise already pointed you at a
 
 ## Codebase Intelligence for all-time-wrestling-rpg (Repowise)
 
-Indexed by [Repowise](https://repowise.dev). Last indexed: 2026-08-11 (commit 89711be15). Confidence: 100%.
+Indexed by [Repowise](https://repowise.dev). Last indexed: 2026-08-11 (commit 0c76b3ad6). Confidence: 100%.
 The MCP tools below serve pre-verified docs, symbols, history, and health from that index. Every response carries `_meta` freshness fields; a `stale_warning` appears only when a file the response actually serves changed after indexing — silence means current.
 
 ### How to work in this repo
@@ -83,7 +83,7 @@ repo is a comprehensive wrestling promotion management platform that consumes us
 
 ### Code health
 
-Three co-equal signals: defect risk 8.25/10 avg, hotspot health 5.59/10 (stable), worst `src/main/java/com/github/javydreamercsw/management/service/campaign/CampaignChapterService.java` at 1.0/10 · maintainability 8.86/10 · performance risk 267 open static I/O-in-loop / N+1 findings. Detail: `get_health()`.
+Three co-equal signals: defect risk 8.25/10 avg, hotspot health 5.6/10 (stable), worst `src/main/java/com/github/javydreamercsw/management/service/campaign/CampaignChapterService.java` at 1.0/10 · maintainability 8.86/10 · performance risk 267 open static I/O-in-loop / N+1 findings. Detail: `get_health()`.
 
 Critical files:
 - `src/main/java/com/github/javydreamercsw/management/service/campaign/PlaceholderResolverService.java` — change entropy — impact −3.0

--- a/.repowise/.update.lock
+++ b/.repowise/.update.lock
@@ -1,0 +1,1 @@
+{"pid": 53412, "pid_create_token": "Tue Aug 11 07:56:45 2026", "target_commit": "65f271ac8bde03cf92ee3f417a27eb886c91ac1d", "started_at": 1786453005.92243}

--- a/.repowise/.update.lock
+++ b/.repowise/.update.lock
@@ -1,1 +1,0 @@
-{"pid": 53412, "pid_create_token": "Tue Aug 11 07:56:45 2026", "target_commit": "65f271ac8bde03cf92ee3f417a27eb886c91ac1d", "started_at": 1786453005.92243}

--- a/src/main/java/com/github/javydreamercsw/management/domain/rivalry/RivalryRepository.java
+++ b/src/main/java/com/github/javydreamercsw/management/domain/rivalry/RivalryRepository.java
@@ -143,6 +143,9 @@ public interface RivalryRepository
       """)
   List<Rivalry> findAllForWrestler(@Param("wrestler") Wrestler wrestler);
 
+  /** Find closed rivalries whose ended_date is before the given cutoff. */
+  List<Rivalry> findByIsActiveFalseAndEndedDateBefore(Instant cutoff);
+
   @Transactional
   @Modifying(clearAutomatically = true)
   @Query("DELETE FROM Rivalry r WHERE r.universe = :universe")

--- a/src/main/java/com/github/javydreamercsw/management/domain/rivalry/heatevent/HeatEventRepository.java
+++ b/src/main/java/com/github/javydreamercsw/management/domain/rivalry/heatevent/HeatEventRepository.java
@@ -17,6 +17,18 @@
 package com.github.javydreamercsw.management.domain.rivalry.heatevent;
 
 import com.github.javydreamercsw.management.domain.rivalry.HeatEvent;
+import com.github.javydreamercsw.management.domain.rivalry.Rivalry;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
-public interface HeatEventRepository extends JpaRepository<HeatEvent, Long> {}
+public interface HeatEventRepository extends JpaRepository<HeatEvent, Long> {
+
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM HeatEvent he WHERE he.rivalry IN :rivalries")
+  int deleteByRivalryIn(@Param("rivalries") List<Rivalry> rivalries);
+}

--- a/src/main/java/com/github/javydreamercsw/management/service/export/UniverseExportService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/export/UniverseExportService.java
@@ -132,6 +132,9 @@ public class UniverseExportService {
       Universe universe, List<WrestlerState> states) {
     List<Map<String, Object>> rows = new ArrayList<>();
     for (var r : rivalryRepository.findByUniverseWithWrestlers(universe)) {
+      if (Boolean.FALSE.equals(r.getIsActive()) && (r.getHeat() == null || r.getHeat() == 0)) {
+        continue;
+      }
       Map<String, Object> row = new LinkedHashMap<>();
       row.put("wrestler1", r.getWrestler1().getName());
       row.put("wrestler2", r.getWrestler2().getName());

--- a/src/main/java/com/github/javydreamercsw/management/service/rivalry/HeatEventCleanupScheduler.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/rivalry/HeatEventCleanupScheduler.java
@@ -1,0 +1,64 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.rivalry;
+
+import com.github.javydreamercsw.base.security.GeneralSecurityUtils;
+import com.github.javydreamercsw.management.service.rivalry.RivalryService.HeatEventCleanupResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * Scheduled cleanup of heat events for closed rivalries. Enabled via {@code
+ * heat.events.cleanup.enabled=true}. Runs weekly; retention threshold is configurable.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(
+    name = "heat.events.cleanup.enabled",
+    havingValue = "true",
+    matchIfMissing = false)
+public class HeatEventCleanupScheduler {
+
+  private final RivalryService rivalryService;
+
+  @Value("${heat.events.retention.days:30}")
+  private int retentionDays;
+
+  @Scheduled(cron = "0 0 3 * * MON")
+  public void runCleanup() {
+    GeneralSecurityUtils.runAsAdmin(
+        () -> {
+          try {
+            log.info(
+                "Starting HeatEvent cleanup (closed rivalries older than {}d)", retentionDays);
+            HeatEventCleanupResult result =
+                rivalryService.purgeClosedRivalryHeatEvents(retentionDays);
+            log.info(
+                "HeatEvent cleanup complete: {} events deleted from {} closed rivalries",
+                result.eventsDeleted(),
+                result.rivalriesProcessed());
+          } catch (Exception e) {
+            log.error("Error during HeatEvent cleanup", e);
+          }
+        });
+  }
+}

--- a/src/main/java/com/github/javydreamercsw/management/service/rivalry/HeatEventCleanupScheduler.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/rivalry/HeatEventCleanupScheduler.java
@@ -48,8 +48,7 @@ public class HeatEventCleanupScheduler {
     GeneralSecurityUtils.runAsAdmin(
         () -> {
           try {
-            log.info(
-                "Starting HeatEvent cleanup (closed rivalries older than {}d)", retentionDays);
+            log.info("Starting HeatEvent cleanup (closed rivalries older than {}d)", retentionDays);
             HeatEventCleanupResult result =
                 rivalryService.purgeClosedRivalryHeatEvents(retentionDays);
             log.info(

--- a/src/main/java/com/github/javydreamercsw/management/service/rivalry/RivalryService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/rivalry/RivalryService.java
@@ -19,6 +19,7 @@ package com.github.javydreamercsw.management.service.rivalry;
 import com.github.javydreamercsw.management.domain.rivalry.Rivalry;
 import com.github.javydreamercsw.management.domain.rivalry.RivalryIntensity;
 import com.github.javydreamercsw.management.domain.rivalry.RivalryRepository;
+import com.github.javydreamercsw.management.domain.rivalry.heatevent.HeatEventRepository;
 import com.github.javydreamercsw.management.domain.universe.Universe;
 import com.github.javydreamercsw.management.domain.universe.UniverseRepository;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
@@ -32,10 +33,12 @@ import com.github.javydreamercsw.management.service.GameSettingService;
 import com.github.javydreamercsw.management.service.resolution.ResolutionResult;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
@@ -50,9 +53,11 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 @Transactional
+@Slf4j
 public class RivalryService {
 
   @Autowired private RivalryRepository rivalryRepository;
+  @Autowired private HeatEventRepository heatEventRepository;
   @Autowired private WrestlerRepository wrestlerRepository;
   @Autowired private UniverseRepository universeRepository;
   @Autowired @Getter private RivalryMapper rivalryMapper;
@@ -471,6 +476,29 @@ public class RivalryService {
 
     return rivalryRepository.hasRivalryHistory(wrestler1Opt.get(), wrestler2Opt.get());
   }
+
+  /**
+   * Delete all heat events belonging to closed rivalries that ended more than {@code retentionDays}
+   * days ago. Returns how many rivalries were processed and how many events were deleted.
+   */
+  @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_SYSTEM')")
+  public HeatEventCleanupResult purgeClosedRivalryHeatEvents(final int retentionDays) {
+    Instant cutoff = Instant.now(clock).minus(retentionDays, ChronoUnit.DAYS);
+    List<Rivalry> stale = rivalryRepository.findByIsActiveFalseAndEndedDateBefore(cutoff);
+    if (stale.isEmpty()) {
+      return new HeatEventCleanupResult(0, 0);
+    }
+    int deleted = heatEventRepository.deleteByRivalryIn(stale);
+    log.info(
+        "HeatEvent cleanup: deleted {} events from {} closed rivalries (ended before {})",
+        deleted,
+        stale.size(),
+        cutoff);
+    return new HeatEventCleanupResult(stale.size(), deleted);
+  }
+
+  /** Result of a heat-event cleanup run. */
+  public record HeatEventCleanupResult(int rivalriesProcessed, int eventsDeleted) {}
 
   /** Rivalry statistics data class. */
   public record RivalryStats(

--- a/src/test/java/com/github/javydreamercsw/management/service/export/UniverseExportServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/export/UniverseExportServiceTest.java
@@ -242,6 +242,37 @@ class UniverseExportServiceTest {
   }
 
   @Test
+  void rivalriesCategory_skipsClosedRivalryWithZeroHeat() {
+    Rivalry closedZeroHeat = mock(Rivalry.class);
+    when(closedZeroHeat.getId()).thenReturn(100L);
+    when(closedZeroHeat.getWrestler1()).thenReturn(activeWrestler);
+    when(closedZeroHeat.getWrestler2()).thenReturn(inactiveWrestler);
+    when(closedZeroHeat.getHeat()).thenReturn(0);
+    when(closedZeroHeat.getIsActive()).thenReturn(false);
+
+    Rivalry closedWithHeat = mock(Rivalry.class);
+    when(closedWithHeat.getId()).thenReturn(101L);
+    when(closedWithHeat.getWrestler1()).thenReturn(activeWrestler);
+    when(closedWithHeat.getWrestler2()).thenReturn(inactiveWrestler);
+    when(closedWithHeat.getHeat()).thenReturn(8);
+    when(closedWithHeat.getHeatEvents()).thenReturn(List.of());
+    when(closedWithHeat.getIsActive()).thenReturn(false);
+    when(closedWithHeat.getStartedDate()).thenReturn(Instant.EPOCH);
+    when(closedWithHeat.getEndedDate()).thenReturn(Instant.EPOCH);
+    when(closedWithHeat.getStorylineNotes()).thenReturn(null);
+
+    when(rivalryRepository.findByUniverseWithWrestlers(universe))
+        .thenReturn(List.of(closedZeroHeat, closedWithHeat));
+
+    ExportPayload payload =
+        service.collect(universe, Set.of(ExportCategory.RIVALRIES), WrestlerFilter.all());
+
+    List<Map<String, Object>> rows = payload.data().get(ExportCategory.RIVALRIES);
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0)).containsEntry("heat", 8);
+  }
+
+  @Test
   void titleReignsCategory_deduplicatesSharedReigns() {
     Title title = mock(Title.class);
     when(title.getName()).thenReturn("World Title");

--- a/src/test/java/com/github/javydreamercsw/management/service/rivalry/HeatEventCleanupSchedulerTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/rivalry/HeatEventCleanupSchedulerTest.java
@@ -1,0 +1,71 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.rivalry;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.management.service.rivalry.RivalryService.HeatEventCleanupResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class HeatEventCleanupSchedulerTest {
+
+  @Mock private RivalryService rivalryService;
+
+  private HeatEventCleanupScheduler scheduler;
+
+  @BeforeEach
+  void setUp() {
+    scheduler = new HeatEventCleanupScheduler(rivalryService);
+    ReflectionTestUtils.setField(scheduler, "retentionDays", 30);
+  }
+
+  @Test
+  void runCleanup_delegatesToRivalryServiceWithConfiguredRetention() {
+    when(rivalryService.purgeClosedRivalryHeatEvents(30))
+        .thenReturn(new HeatEventCleanupResult(2, 10));
+
+    scheduler.runCleanup();
+
+    verify(rivalryService).purgeClosedRivalryHeatEvents(30);
+  }
+
+  @Test
+  void runCleanup_withCustomRetention_passesCorrectDays() {
+    ReflectionTestUtils.setField(scheduler, "retentionDays", 60);
+    when(rivalryService.purgeClosedRivalryHeatEvents(60))
+        .thenReturn(new HeatEventCleanupResult(0, 0));
+
+    scheduler.runCleanup();
+
+    verify(rivalryService).purgeClosedRivalryHeatEvents(60);
+  }
+
+  @Test
+  void runCleanup_serviceThrowsException_doesNotPropagate() {
+    when(rivalryService.purgeClosedRivalryHeatEvents(30))
+        .thenThrow(new RuntimeException("Simulated failure"));
+
+    scheduler.runCleanup();
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/service/rivalry/RivalryServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/rivalry/RivalryServiceTest.java
@@ -459,8 +459,7 @@ class RivalryServiceTest {
         .thenReturn(List.of(stale));
     when(heatEventRepository.deleteByRivalryIn(List.of(stale))).thenReturn(5);
 
-    RivalryService.HeatEventCleanupResult result =
-        rivalryService.purgeClosedRivalryHeatEvents(30);
+    RivalryService.HeatEventCleanupResult result = rivalryService.purgeClosedRivalryHeatEvents(30);
 
     assertThat(result.rivalriesProcessed()).isEqualTo(1);
     assertThat(result.eventsDeleted()).isEqualTo(5);
@@ -476,8 +475,7 @@ class RivalryServiceTest {
     when(rivalryRepository.findByIsActiveFalseAndEndedDateBefore(any(Instant.class)))
         .thenReturn(List.of());
 
-    RivalryService.HeatEventCleanupResult result =
-        rivalryService.purgeClosedRivalryHeatEvents(30);
+    RivalryService.HeatEventCleanupResult result = rivalryService.purgeClosedRivalryHeatEvents(30);
 
     assertThat(result.rivalriesProcessed()).isZero();
     assertThat(result.eventsDeleted()).isZero();

--- a/src/test/java/com/github/javydreamercsw/management/service/rivalry/RivalryServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/rivalry/RivalryServiceTest.java
@@ -34,7 +34,6 @@ import com.github.javydreamercsw.management.service.GameSettingService;
 import com.github.javydreamercsw.management.service.resolution.ResolutionResult;
 import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
@@ -448,7 +447,6 @@ class RivalryServiceTest {
   void purgeClosedRivalryHeatEvents_deletesEventsForStaleRivalries() {
     Instant now = Instant.parse("2026-08-10T10:00:00Z");
     when(clock.instant()).thenReturn(now);
-    when(clock.getZone()).thenReturn(ZoneOffset.UTC);
 
     Rivalry stale = createRivalry(createWrestler("A", 1L), createWrestler("B", 2L), 0);
     stale.setIsActive(false);
@@ -470,7 +468,6 @@ class RivalryServiceTest {
   void purgeClosedRivalryHeatEvents_returnsZeroWhenNothingToClean() {
     Instant now = Instant.parse("2026-08-10T10:00:00Z");
     when(clock.instant()).thenReturn(now);
-    when(clock.getZone()).thenReturn(ZoneOffset.UTC);
 
     when(rivalryRepository.findByIsActiveFalseAndEndedDateBefore(any(Instant.class)))
         .thenReturn(List.of());

--- a/src/test/java/com/github/javydreamercsw/management/service/rivalry/RivalryServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/rivalry/RivalryServiceTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.github.javydreamercsw.management.domain.rivalry.Rivalry;
 import com.github.javydreamercsw.management.domain.rivalry.RivalryIntensity;
 import com.github.javydreamercsw.management.domain.rivalry.RivalryRepository;
+import com.github.javydreamercsw.management.domain.rivalry.heatevent.HeatEventRepository;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.event.HeatChangeEvent;
@@ -33,6 +34,8 @@ import com.github.javydreamercsw.management.service.GameSettingService;
 import com.github.javydreamercsw.management.service.resolution.ResolutionResult;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -53,6 +56,7 @@ import org.springframework.context.ApplicationEventPublisher;
 class RivalryServiceTest {
 
   @Mock private RivalryRepository rivalryRepository;
+  @Mock private HeatEventRepository heatEventRepository;
   @Mock private WrestlerRepository wrestlerRepository;
 
   @Mock
@@ -437,6 +441,46 @@ class RivalryServiceTest {
     wrestler.setWrestlerStates(new java.util.LinkedHashSet<>(java.util.List.of(state)));
 
     return wrestler;
+  }
+
+  @Test
+  @DisplayName("purgeClosedRivalryHeatEvents: deletes events for stale closed rivalries")
+  void purgeClosedRivalryHeatEvents_deletesEventsForStaleRivalries() {
+    Instant now = Instant.parse("2026-08-10T10:00:00Z");
+    when(clock.instant()).thenReturn(now);
+    when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+
+    Rivalry stale = createRivalry(createWrestler("A", 1L), createWrestler("B", 2L), 0);
+    stale.setIsActive(false);
+    stale.setEndedDate(now.minus(60, ChronoUnit.DAYS));
+
+    Instant cutoff = now.minus(30, ChronoUnit.DAYS);
+    when(rivalryRepository.findByIsActiveFalseAndEndedDateBefore(cutoff))
+        .thenReturn(List.of(stale));
+    when(heatEventRepository.deleteByRivalryIn(List.of(stale))).thenReturn(5);
+
+    RivalryService.HeatEventCleanupResult result =
+        rivalryService.purgeClosedRivalryHeatEvents(30);
+
+    assertThat(result.rivalriesProcessed()).isEqualTo(1);
+    assertThat(result.eventsDeleted()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("purgeClosedRivalryHeatEvents: returns zero when no stale rivalries exist")
+  void purgeClosedRivalryHeatEvents_returnsZeroWhenNothingToClean() {
+    Instant now = Instant.parse("2026-08-10T10:00:00Z");
+    when(clock.instant()).thenReturn(now);
+    when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+
+    when(rivalryRepository.findByIsActiveFalseAndEndedDateBefore(any(Instant.class)))
+        .thenReturn(List.of());
+
+    RivalryService.HeatEventCleanupResult result =
+        rivalryService.purgeClosedRivalryHeatEvents(30);
+
+    assertThat(result.rivalriesProcessed()).isZero();
+    assertThat(result.eventsDeleted()).isZero();
   }
 
   private Rivalry createRivalry(


### PR DESCRIPTION
## Summary

- **Export filter**: `UniverseExportService.collectRivalries()` now skips closed rivalries with `heat == 0` — they carry no actionable context for AI prompts
- **Bulk delete query**: `HeatEventRepository.deleteByRivalryIn()` — JPQL `@Modifying` delete for a list of rivalries
- **Repository finder**: `RivalryRepository.findByIsActiveFalseAndEndedDateBefore()` — locates closed rivalries past a configurable retention window
- **Service method**: `RivalryService.purgeClosedRivalryHeatEvents(retentionDays)` — admin/system-role-gated, returns `HeatEventCleanupResult` record
- **Scheduler**: `HeatEventCleanupScheduler` — opt-in via `heat.events.cleanup.enabled=true`, runs every Monday at 03:00, default 30-day retention

## Test plan

- [x] `HeatEventCleanupSchedulerTest` — covers delegation, custom retention, and exception-swallowing (added to fix `codecov/patch`)
- [x] `UniverseExportServiceTest.rivalriesCategory_skipsClosedRivalryWithZeroHeat`
- [x] `RivalryServiceTest.purgeClosedRivalryHeatEvents_deletesEventsForStaleRivalries`
- [x] `RivalryServiceTest.purgeClosedRivalryHeatEvents_returnsZeroWhenNothingToClean`
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwrA69Brbm8nUPhswhjHcZ