### PR TITLE
feat(ATW-ntjb): add data-driven achievement unlock conditions (scripting)

### DIFF
--- a/docs/CAMPAIGN_SCRIPTING.md
+++ b/docs/CAMPAIGN_SCRIPTING.md
@@ -9,6 +9,8 @@ Ability cards in the campaign (Face/Heel cards, Ally/Valet cards) use a simple s
 Scripts are stored in the `effect_script` and `secondary_effect_script` columns of the `campaign_ability_card` table.
 
 > **Note:** This same scripting engine is also used for **Title Abilities**. Titles can use a subset of these methods to influence AI narration. See the [Content Management Guide](CONTENT_GUIDE.md) for details.
+>
+> **Note:** A related but separate Groovy-based scripting surface exists for **Achievement unlock conditions** (`achievements.json`'s `unlockCondition` field). It does not use `CampaignEffectContext` and has its own variable bindings per check site. See [Content Management Guide § Scripted unlock conditions](CONTENT_GUIDE.md#scripted-unlock-conditions).
 
 ## Script Syntax
 

--- a/docs/CONTENT_GUIDE.md
+++ b/docs/CONTENT_GUIDE.md
@@ -455,13 +455,14 @@ Achievements are persistent player rewards with an XP value. They are loaded fro
 
 ### Field reference
 
-|     Field     |                                                                         Description                                                                          |
-|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `key`         | Unique string identifier. Must match the key passed to `LegacyService.unlockAchievement()` exactly — a mismatch means the achievement silently never awards. |
-| `name`        | Short display name shown in the player profile.                                                                                                              |
-| `description` | One-sentence description of what the player did to earn it.                                                                                                  |
-| `xpValue`     | Prestige XP awarded on unlock.                                                                                                                               |
-| `category`    | One of `COLLECTION`, `FANS`, `CHAMPIONSHIP`, `MATCH_TYPE`, `BOOKING`, `SPECIAL_EVENT`, `CHALLENGE`.                                                          |
+|       Field       |                                                                         Description                                                                          |
+|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `key`             | Unique string identifier. Must match the key passed to `LegacyService.unlockAchievement()` exactly — a mismatch means the achievement silently never awards. |
+| `name`            | Short display name shown in the player profile.                                                                                                              |
+| `description`     | One-sentence description of what the player did to earn it.                                                                                                  |
+| `xpValue`         | Prestige XP awarded on unlock.                                                                                                                               |
+| `category`        | One of `COLLECTION`, `FANS`, `CHAMPIONSHIP`, `MATCH_TYPE`, `BOOKING`, `SPECIAL_EVENT`, `CHALLENGE`.                                                          |
+| `unlockCondition` | Optional. A Groovy boolean expression — see [Scripted unlock conditions](#scripted-unlock-conditions). Omit for achievements unlocked only from Java code.   |
 
 ### Categories
 
@@ -486,9 +487,71 @@ Achievements are persistent player rewards with an XP value. They are loaded fro
 
 Non-challenge achievements (match-type, collection, etc.) are unlocked by calling `LegacyService.unlockAchievement(account, key)` from the relevant service layer. `unlockAchievement` is idempotent — calling it multiple times for the same account and key is safe.
 
+### Scripted unlock conditions
+
+Achievement *metadata* has always lived in `achievements.json`, but until the `unlockCondition` field existed, the *unlock logic itself* was 100% hardcoded Java spread across three services. `unlockCondition` lets you add a new achievement — including its trigger condition — by editing `achievements.json` alone, as long as the condition can be expressed against the variables already available at one of the three existing check sites below. No Java change, no recompile.
+
+`unlockCondition` is a Groovy expression that must evaluate to `true`/`false`. It is evaluated by `AchievementScriptService` (`management/service/achievement/`), which fails **closed**: a syntax error, a runtime exception, or a non-boolean result is logged and treated as "not unlocked" — a broken script can never crash gameplay or block an achievement check for every other player. Compiled scripts are cached by snippet text, and an achievement the account already holds is skipped before its script is even compiled, so scripted achievements add negligible overhead.
+
+`unlockCondition` is evaluated once per relevant event, at each of the three sites that already check achievements. Each site binds a different set of variables:
+
+**`LegacyService.checkAchievements`** (runs on every legacy score recalculation — roster/fan/title changes):
+
+|      Variable       |       Type       |                         Meaning                         |
+|---------------------|------------------|---------------------------------------------------------|
+| `account`           | `Account`        | The account being evaluated.                            |
+| `wrestlers`         | `List<Wrestler>` | All wrestlers managed by the account.                   |
+| `totalFans`         | `long`           | Sum of fans across all managed wrestlers.               |
+| `currentTitlesHeld` | `long`           | Count of titles currently held by any managed wrestler. |
+
+**`ChallengeCompletionService.checkAchievements`** (runs on first completion of a challenge):
+
+|        Variable         |        Type         |                     Meaning                      |
+|-------------------------|---------------------|--------------------------------------------------|
+| `account`               | `Account`           | The account completing the challenge.            |
+| `challenge`             | `ChallengeDTO`      | The challenge just completed.                    |
+| `challengeId`           | `String`            | The completed challenge's ID.                    |
+| `difficulty`            | `Difficulty`        | The completed challenge's difficulty.            |
+| `season`                | `String` (nullable) | The completed challenge's season label, if any.  |
+| `totalCompleted`        | `long`              | Total completed-challenge count for the account. |
+| `hardCompletedCount`    | `long`              | Count of completed HARD-difficulty challenges.   |
+| `completedChallengeIds` | `Set<String>`       | IDs of all challenges the account has completed. |
+
+**`SegmentAdjudicationService.triggerAchievements`** (runs per participant after every match adjudication):
+
+|       Variable       |       Type       |                      Meaning                       |
+|----------------------|------------------|----------------------------------------------------|
+| `segment`            | `Segment`        | The adjudicated segment.                           |
+| `winners`            | `List<Wrestler>` | The segment's winners.                             |
+| `participant`        | `Wrestler`       | The wrestler this evaluation is for.               |
+| `isWinner`           | `boolean`        | Whether `participant` is a winner.                 |
+| `isMainEvent`        | `boolean`        | Whether the segment was the show's main event.     |
+| `isPremiumLiveEvent` | `boolean`        | Whether the show is a Premium Live Event.          |
+| `segmentTypeName`    | `String`         | The segment type's display name.                   |
+| `segmentRuleNames`   | `List<String>`   | Display names of the segment's rules/stipulations. |
+
+Example — a script-only achievement with no corresponding Java, added purely via `achievements.json`:
+
+```json
+{
+  "key": "ELITE_SCOUT",
+  "name": "Elite Scout",
+  "description": "Build a roster of 20 wrestlers while holding at least 3 titles",
+  "xpValue": 750,
+  "category": "COLLECTION",
+  "unlockCondition": "wrestlers.size() >= 20 && currentTitlesHeld >= 3"
+}
+```
+
+**Limitation:** a condition that needs data not available at any of the three sites above (e.g. "wrestler retires") still requires a new Java call site invoking `ScriptedAchievementEvaluator.resolveNewlyUnlockedKeys(...)` — this mechanism only covers the three existing choke points, not arbitrary new game events.
+
 ### Adding a new achievement
 
-1. Add an entry to `achievements.json` with a unique `key`.
+**Preferred path — no Java change:** if the trigger condition can be expressed against the variables available at one of the three sites in [Scripted unlock conditions](#scripted-unlock-conditions), add an entry to `achievements.json` with a unique `key` and an `unlockCondition` script. Nothing else is required.
+
+**Java-triggered path** — needed only for a genuinely new trigger point:
+
+1. Add an entry to `achievements.json` with a unique `key` (omit `unlockCondition`).
 2. Call `legacyService.unlockAchievement(account, "YOUR_KEY")` from the service that should trigger it.
 3. If the achievement is paired with a new challenge, set `achievementKey` on the challenge entry.
 4. Add a test that verifies `unlockAchievement` is called with the correct key string (see `ChallengeCompletionServiceTest` for patterns to follow).

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -9,7 +9,7 @@ This guide provides instructions for developers on how to work with the security
 - [Securing Service Methods](#securing-service-methods)
 - [Ownership-Based Security for Players](#ownership-based-security-for-players)
 - [Role-Based UI Components](#role-based-ui-components)
-- [Campaign System Scripting](#campaign-system-scripting)
+- [Dynamic Scripting (Campaign & Achievements)](#dynamic-scripting-campaign--achievements)
 
 ## Security Architecture Overview
 
@@ -115,9 +115,11 @@ The `SecurityUtils` class provides the following convenient methods:
 
 Always use these `SecurityUtils` methods to control the visibility of UI components based on the current user's permissions. This ensures that the UI accurately reflects what the user is allowed to do, as enforced by the backend's method-level security.
 
-## Campaign System Scripting
+## Dynamic Scripting (Campaign & Achievements)
 
-The solo campaign uses dynamic scripting for ability cards (Ally, Valet, Face/Heel cards). For a detailed guide on available methods and script syntax, refer to the [Campaign Scripting Guide](CAMPAIGN_SCRIPTING.md).
+The solo campaign uses dynamic scripting for ability cards (Ally, Valet, Face/Heel cards), chapter progression criteria, and status card trigger conditions. For a detailed guide on available methods and script syntax, refer to the [Campaign Scripting Guide](CAMPAIGN_SCRIPTING.md).
+
+Achievement unlock conditions use the same trusted-content-only Groovy pattern: an optional `unlockCondition` script on each `achievements.json` entry, evaluated by `AchievementScriptService` (fail-closed — a broken script is logged and treated as "not unlocked", never propagated). As with campaign scripts, this executes arbitrary Groovy against shipped JSON content, not user-supplied input — treat new script sources the same way when reviewing for security implications. See [Content Management Guide § Scripted unlock conditions](CONTENT_GUIDE.md#scripted-unlock-conditions) for the field reference and available variables.
 
 ## Tournament Format System
 

--- a/src/main/java/com/github/javydreamercsw/base/domain/account/Achievement.java
+++ b/src/main/java/com/github/javydreamercsw/base/domain/account/Achievement.java
@@ -59,4 +59,12 @@ public class Achievement extends AbstractEntity<Long> {
 
   @Column(name = "icon_url")
   @Size(max = 512) private String iconUrl;
+
+  /**
+   * Optional Groovy boolean expression evaluated against a context map at the relevant unlock check
+   * site. Null means no scripted condition — the achievement relies solely on hardcoded Java checks
+   * (if any). See AchievementScriptService for evaluation semantics.
+   */
+  @Column(name = "unlock_condition", length = 2000)
+  @Size(max = 2000) private String unlockCondition;
 }

--- a/src/main/java/com/github/javydreamercsw/base/domain/account/AchievementRepository.java
+++ b/src/main/java/com/github/javydreamercsw/base/domain/account/AchievementRepository.java
@@ -16,6 +16,7 @@
 */
 package com.github.javydreamercsw.base.domain.account;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -23,4 +24,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AchievementRepository extends JpaRepository<Achievement, Long> {
   Optional<Achievement> findByKey(String key);
+
+  List<Achievement> findByUnlockConditionIsNotNull();
 }

--- a/src/main/java/com/github/javydreamercsw/management/config/CacheConfig.java
+++ b/src/main/java/com/github/javydreamercsw/management/config/CacheConfig.java
@@ -58,6 +58,7 @@ public class CacheConfig {
   public static final String LOCATIONS_CACHE = "locations";
   public static final String UNIVERSES_CACHE = "universes";
   public static final String TIER_BOUNDARIES_CACHE = "tierBoundaries";
+  public static final String SCRIPTED_ACHIEVEMENTS_CACHE = "scriptedAchievements";
 
   /**
    * Configures the cache manager with optimized cache settings. Uses Caffeine for thread-safe
@@ -86,7 +87,8 @@ public class CacheConfig {
             ARENAS_CACHE,
             LOCATIONS_CACHE,
             UNIVERSES_CACHE,
-            TIER_BOUNDARIES_CACHE));
+            TIER_BOUNDARIES_CACHE,
+            SCRIPTED_ACHIEVEMENTS_CACHE));
 
     // Default spec for all caches
     cacheManager.setCaffeine(

--- a/src/main/java/com/github/javydreamercsw/management/service/achievement/AchievementDefinitionService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/achievement/AchievementDefinitionService.java
@@ -1,0 +1,43 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.achievement;
+
+import com.github.javydreamercsw.base.domain.account.Achievement;
+import com.github.javydreamercsw.base.domain.account.AchievementRepository;
+import com.github.javydreamercsw.management.config.CacheConfig;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+/**
+ * Cached lookup of achievements that carry a scripted unlock condition, so the achievement-check
+ * call sites (legacy score recalculation, challenge completion, match adjudication) don't hit the
+ * database on every event. Evicted by {@code AchievementSync} whenever achievements.json is
+ * re-synced.
+ */
+@Service
+@RequiredArgsConstructor
+public class AchievementDefinitionService {
+
+  private final AchievementRepository achievementRepository;
+
+  @Cacheable(value = CacheConfig.SCRIPTED_ACHIEVEMENTS_CACHE, key = "'all'")
+  public List<Achievement> getScriptedAchievements() {
+    return achievementRepository.findByUnlockConditionIsNotNull();
+  }
+}

--- a/src/main/java/com/github/javydreamercsw/management/service/achievement/AchievementScriptService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/achievement/AchievementScriptService.java
@@ -1,0 +1,62 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.achievement;
+
+import groovy.lang.Binding;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.runtime.InvokerHelper;
+import org.springframework.stereotype.Service;
+
+/**
+ * Evaluates Groovy boolean expressions used as achievement unlock conditions. Compiled script
+ * classes are cached by snippet text since achievement checks run on every legacy score
+ * recalculation, challenge completion, and match adjudication — a hot path where recompiling the
+ * same snippet on every call would be wasted work.
+ *
+ * <p>Fails closed: any exception (syntax error, runtime error, non-boolean result) is logged and
+ * treated as "not unlocked" rather than propagated, since a broken achievement script must never
+ * block gameplay.
+ */
+@Service
+@Slf4j
+public class AchievementScriptService {
+
+  private final Map<String, Class<?>> compiledScriptCache = new ConcurrentHashMap<>();
+  private final groovy.lang.GroovyClassLoader groovyClassLoader =
+      new groovy.lang.GroovyClassLoader(
+          Thread.currentThread().getContextClassLoader(), new CompilerConfiguration());
+
+  public boolean evaluate(final String script, @NonNull final Map<String, Object> variables) {
+    if (script == null || script.isBlank()) {
+      return false;
+    }
+    try {
+      Class<?> scriptClass =
+          compiledScriptCache.computeIfAbsent(script, groovyClassLoader::parseClass);
+      Binding binding = new Binding(variables);
+      Object result = InvokerHelper.createScript(scriptClass, binding).run();
+      return Boolean.TRUE.equals(result);
+    } catch (Exception e) {
+      log.warn("Achievement unlock script failed — treating as not-unlocked: {}", e.getMessage());
+      return false;
+    }
+  }
+}

--- a/src/main/java/com/github/javydreamercsw/management/service/achievement/ScriptedAchievementEvaluator.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/achievement/ScriptedAchievementEvaluator.java
@@ -1,0 +1,66 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.achievement;
+
+import com.github.javydreamercsw.base.domain.account.Account;
+import com.github.javydreamercsw.base.domain.account.Achievement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves which data-defined (scripted) achievements newly qualify for an account, given a context
+ * map of the variables available at a given unlock-check call site. Does not perform the unlock
+ * itself — callers pass the returned keys to {@code LegacyService.unlockAchievement}, the existing
+ * generic unlock sink, so XP award, per-account dedup, legacy score recalculation, and event
+ * publishing stay unchanged.
+ *
+ * <p>Deliberately has no dependency on {@code LegacyService} to avoid a bean cycle, since {@code
+ * LegacyService} depends on this class.
+ */
+@Service
+@RequiredArgsConstructor
+public class ScriptedAchievementEvaluator {
+
+  private final AchievementDefinitionService definitionService;
+  private final AchievementScriptService scriptService;
+
+  /**
+   * Returns the keys of scripted achievements the account newly qualifies for. Achievements the
+   * account already holds are skipped before their script is compiled or evaluated.
+   */
+  public List<String> resolveNewlyUnlockedKeys(
+      @NonNull final Account account, @NonNull final Map<String, Object> context) {
+    Set<String> alreadyUnlocked =
+        account.getAchievements().stream().map(Achievement::getKey).collect(Collectors.toSet());
+    List<String> newlyUnlocked = new ArrayList<>();
+    for (Achievement candidate : definitionService.getScriptedAchievements()) {
+      if (alreadyUnlocked.contains(candidate.getKey())) {
+        continue;
+      }
+      if (scriptService.evaluate(candidate.getUnlockCondition(), context)) {
+        newlyUnlocked.add(candidate.getKey());
+      }
+    }
+    return newlyUnlocked;
+  }
+}

--- a/src/main/java/com/github/javydreamercsw/management/service/challenge/ChallengeCompletionService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/challenge/ChallengeCompletionService.java
@@ -21,9 +21,12 @@ import com.github.javydreamercsw.management.domain.campaign.Difficulty;
 import com.github.javydreamercsw.management.domain.challenge.AccountChallengeCompletion;
 import com.github.javydreamercsw.management.domain.challenge.AccountChallengeCompletionRepository;
 import com.github.javydreamercsw.management.domain.challenge.ChallengeCompletionStatus;
+import com.github.javydreamercsw.management.service.achievement.ScriptedAchievementEvaluator;
 import com.github.javydreamercsw.management.service.legacy.LegacyService;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -41,6 +44,7 @@ public class ChallengeCompletionService {
   private final AccountChallengeCompletionRepository repository;
   private final ChallengeService challengeService;
   private final LegacyService legacyService;
+  private final ScriptedAchievementEvaluator scriptedAchievementEvaluator;
 
   @Transactional(readOnly = true)
   public Optional<AccountChallengeCompletion> find(
@@ -99,6 +103,17 @@ public class ChallengeCompletionService {
         .getChallenge(challengeId)
         .ifPresent(
             challenge -> {
+              Set<String> completedIds = completedChallengeIds(account);
+              long total =
+                  repository.findByAccount(account).stream()
+                      .filter(c -> ChallengeCompletionStatus.COMPLETED == c.getStatus())
+                      .count();
+              long hardCompletedCount =
+                  challengeService.getAllChallenges().stream()
+                      .filter(c -> Difficulty.HARD == c.getDifficulty())
+                      .filter(c -> completedIds.contains(c.getId()))
+                      .count();
+
               // Per-challenge achievement
               if (challenge.getAchievementKey() != null
                   && !challenge.getAchievementKey().isBlank()) {
@@ -106,22 +121,13 @@ public class ChallengeCompletionService {
               }
 
               // First HARD difficulty completion
-              if (Difficulty.HARD == challenge.getDifficulty()) {
-                Set<String> completedIds = completedChallengeIds(account);
-                long hardCount =
-                    challengeService.getAllChallenges().stream()
-                        .filter(c -> Difficulty.HARD == c.getDifficulty())
-                        .filter(c -> completedIds.contains(c.getId()))
-                        .count();
-                if (hardCount == 1) {
-                  legacyService.unlockAchievement(account, "CHALLENGE_FIRST_HARD");
-                }
+              if (Difficulty.HARD == challenge.getDifficulty() && hardCompletedCount == 1) {
+                legacyService.unlockAchievement(account, "CHALLENGE_FIRST_HARD");
               }
 
               // Season completion
               String season = challenge.getSeason();
               if (season != null && !season.isBlank()) {
-                Set<String> completedIds = completedChallengeIds(account);
                 boolean seasonDone =
                     challengeService.getActiveChallenges().stream()
                         .filter(c -> season.equals(c.getSeason()))
@@ -133,16 +139,25 @@ public class ChallengeCompletionService {
               }
 
               // Cumulative count milestones
-              long total =
-                  repository.findByAccount(account).stream()
-                      .filter(c -> ChallengeCompletionStatus.COMPLETED == c.getStatus())
-                      .count();
               if (total >= 10) {
                 legacyService.unlockAchievement(account, "CHALLENGE_10_COMPLETE");
               }
               if (total >= 5) {
                 legacyService.unlockAchievement(account, "CHALLENGE_5_COMPLETE");
               }
+
+              Map<String, Object> context = new HashMap<>();
+              context.put("account", account);
+              context.put("challenge", challenge);
+              context.put("challengeId", challengeId);
+              context.put("difficulty", challenge.getDifficulty());
+              context.put("season", season);
+              context.put("totalCompleted", total);
+              context.put("hardCompletedCount", hardCompletedCount);
+              context.put("completedChallengeIds", completedIds);
+              scriptedAchievementEvaluator
+                  .resolveNewlyUnlockedKeys(account, context)
+                  .forEach(key -> legacyService.unlockAchievement(account, key));
             });
   }
 

--- a/src/main/java/com/github/javydreamercsw/management/service/legacy/LegacyService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/legacy/LegacyService.java
@@ -26,7 +26,10 @@ import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.event.AchievementUnlockedEvent;
+import com.github.javydreamercsw.management.service.achievement.ScriptedAchievementEvaluator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
@@ -46,6 +49,7 @@ public class LegacyService {
   private final AchievementRepository achievementRepository;
   private final TitleRepository titleRepository;
   private final ApplicationEventPublisher eventPublisher;
+  private final ScriptedAchievementEvaluator scriptedAchievementEvaluator;
 
   /**
    * Recalculates the legacy score for an account based on their managed wrestlers. Formula: - 1
@@ -137,6 +141,15 @@ public class LegacyService {
         unlockAchievement(account, "GRAND_SLAM");
       }
     }
+
+    Map<String, Object> context = new HashMap<>();
+    context.put("account", account);
+    context.put("wrestlers", wrestlers);
+    context.put("totalFans", totalFans);
+    context.put("currentTitlesHeld", currentTitlesHeld);
+    scriptedAchievementEvaluator
+        .resolveNewlyUnlockedKeys(account, context)
+        .forEach(key -> unlockAchievement(account, key));
   }
 
   @Transactional

--- a/src/main/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/match/SegmentAdjudicationService.java
@@ -38,6 +38,7 @@ import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.event.ChampionshipChangeEvent;
 import com.github.javydreamercsw.management.event.ChampionshipDefendedEvent;
 import com.github.javydreamercsw.management.service.GameSettingService;
+import com.github.javydreamercsw.management.service.achievement.ScriptedAchievementEvaluator;
 import com.github.javydreamercsw.management.service.campaign.AlignmentService;
 import com.github.javydreamercsw.management.service.campaign.WrestlerStatusService;
 import com.github.javydreamercsw.management.service.faction.FactionService;
@@ -111,6 +112,11 @@ public class SegmentAdjudicationService {
 
   @Setter(onMethod_ = {@Autowired})
   private OutcomeMatrixService outcomeMatrixService;
+
+  // Field-injected for the same reason — null-safe, scripted achievement evaluation is skipped
+  // when null (unit tests).
+  @Setter(onMethod_ = {@Autowired})
+  private ScriptedAchievementEvaluator scriptedAchievementEvaluator;
 
   @Autowired
   public SegmentAdjudicationService(
@@ -696,6 +702,23 @@ public class SegmentAdjudicationService {
           if (segment.getShow().isPremiumLiveEvent()) {
             legacyService.unlockAchievement(participant.getAccount(), "MAIN_EVENT_PLE");
           }
+        }
+
+        if (scriptedAchievementEvaluator != null) {
+          Map<String, Object> context = new HashMap<>();
+          context.put("segment", segment);
+          context.put("winners", winners);
+          context.put("participant", participant);
+          context.put("isWinner", winners.contains(participant));
+          context.put("isMainEvent", segment.isMainEvent());
+          context.put("isPremiumLiveEvent", segment.getShow().isPremiumLiveEvent());
+          context.put("segmentTypeName", segment.getSegmentType().getName());
+          context.put(
+              "segmentRuleNames",
+              segment.getSegmentRules().stream().map(SegmentRule::getName).toList());
+          scriptedAchievementEvaluator
+              .resolveNewlyUnlockedKeys(participant.getAccount(), context)
+              .forEach(key -> legacyService.unlockAchievement(participant.getAccount(), key));
         }
       }
     }

--- a/src/main/java/com/github/javydreamercsw/management/sync/AchievementSync.java
+++ b/src/main/java/com/github/javydreamercsw/management/sync/AchievementSync.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javydreamercsw.base.domain.account.Achievement;
 import com.github.javydreamercsw.base.domain.account.AchievementRepository;
+import com.github.javydreamercsw.management.config.CacheConfig;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +28,7 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
@@ -51,6 +53,7 @@ public class AchievementSync implements DataSyncContributor {
   }
 
   @Override
+  @CacheEvict(value = CacheConfig.SCRIPTED_ACHIEVEMENTS_CACHE, allEntries = true)
   public void sync() {
     if (skipIfNotEmpty && achievementRepository.count() > 0) {
       return;
@@ -69,6 +72,7 @@ public class AchievementSync implements DataSyncContributor {
             existing.setDescription(a.getDescription());
             existing.setXpValue(a.getXpValue());
             existing.setCategory(a.getCategory());
+            existing.setUnlockCondition(a.getUnlockCondition());
             toSave.add(existing);
           } else {
             toSave.add(a);

--- a/src/main/resources/achievements.json
+++ b/src/main/resources/achievements.json
@@ -3,7 +3,22 @@
   "name": "Rookie Manager",
   "description": "Manage your first wrestler",
   "xpValue": 50,
-  "category": "COLLECTION"
+  "category": "COLLECTION",
+  "unlockCondition": "!wrestlers.isEmpty()"
+}, {
+  "key": "ELITE_SCOUT",
+  "name": "Elite Scout",
+  "description": "Build a roster of 20 wrestlers while holding at least 3 titles",
+  "xpValue": 750,
+  "category": "COLLECTION",
+  "unlockCondition": "wrestlers.size() >= 20 && currentTitlesHeld >= 3"
+}, {
+  "key": "PLE_MAIN_EVENT_WINNER",
+  "name": "Unstoppable Force",
+  "description": "Win a main event at a Premium Live Event",
+  "xpValue": 1500,
+  "category": "SPECIAL_EVENT",
+  "unlockCondition": "isWinner && isMainEvent && isPremiumLiveEvent"
 }, {
   "key": "ROSTER_BUILDER",
   "name": "Talent Scout",

--- a/src/main/resources/db/migration/h2/V130__Add_Unlock_Condition_To_Achievement.sql
+++ b/src/main/resources/db/migration/h2/V130__Add_Unlock_Condition_To_Achievement.sql
@@ -1,0 +1,1 @@
+ALTER TABLE achievement ADD COLUMN IF NOT EXISTS unlock_condition VARCHAR(2000);

--- a/src/main/resources/db/migration/mysql/V99__Add_Unlock_Condition_To_Achievement.sql
+++ b/src/main/resources/db/migration/mysql/V99__Add_Unlock_Condition_To_Achievement.sql
@@ -1,0 +1,1 @@
+ALTER TABLE achievement ADD COLUMN unlock_condition VARCHAR(2000);

--- a/src/test/java/com/github/javydreamercsw/management/service/achievement/AchievementScriptServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/achievement/AchievementScriptServiceTest.java
@@ -1,0 +1,79 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.achievement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AchievementScriptServiceTest {
+
+  private final AchievementScriptService service = new AchievementScriptService();
+
+  @Test
+  @DisplayName("Groovy script returning true unlocks the achievement")
+  void testScriptReturningTrue() {
+    assertThat(service.evaluate("true", Map.of())).isTrue();
+  }
+
+  @Test
+  @DisplayName("Groovy script returning false does not unlock the achievement")
+  void testScriptReturningFalse() {
+    assertThat(service.evaluate("false", Map.of())).isFalse();
+  }
+
+  @Test
+  @DisplayName("Script can read bound context variables")
+  void testScriptCanAccessContext() {
+    assertThat(
+            service.evaluate("wrestlers.size() >= 2", Map.of("wrestlers", java.util.List.of(1, 2))))
+        .isTrue();
+    assertThat(service.evaluate("wrestlers.size() >= 2", Map.of("wrestlers", java.util.List.of(1))))
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("Script that throws returns false and does not propagate")
+  void testScriptExceptionReturnsFalse() {
+    assertThat(service.evaluate("throw new RuntimeException('boom')", Map.of())).isFalse();
+  }
+
+  @Test
+  @DisplayName("Null or blank script is treated as not-unlocked")
+  void testNullOrBlankScript() {
+    assertThat(service.evaluate(null, Map.of())).isFalse();
+    assertThat(service.evaluate("", Map.of())).isFalse();
+    assertThat(service.evaluate("   ", Map.of())).isFalse();
+  }
+
+  @Test
+  @DisplayName("Non-boolean script result is treated as not-unlocked")
+  void testNonBooleanResultReturnsFalse() {
+    assertThat(service.evaluate("'not a boolean'", Map.of())).isFalse();
+  }
+
+  @Test
+  @DisplayName("Repeated evaluation of the same script reuses the compiled class")
+  void testRepeatedEvaluationIsConsistent() {
+    String script = "wrestlers.size() >= 2";
+    for (int i = 0; i < 3; i++) {
+      assertThat(service.evaluate(script, Map.of("wrestlers", java.util.List.of(1, 2)))).isTrue();
+    }
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/service/achievement/ScriptedAchievementEvaluatorTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/achievement/ScriptedAchievementEvaluatorTest.java
@@ -1,0 +1,106 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.achievement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.javydreamercsw.base.domain.account.Account;
+import com.github.javydreamercsw.base.domain.account.Achievement;
+import com.github.javydreamercsw.base.domain.account.AchievementCategory;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ScriptedAchievementEvaluatorTest {
+
+  @Mock private AchievementDefinitionService definitionService;
+  @Mock private AchievementScriptService scriptService;
+
+  private ScriptedAchievementEvaluator evaluator;
+  private Account account;
+
+  @BeforeEach
+  void setUp() {
+    evaluator = new ScriptedAchievementEvaluator(definitionService, scriptService);
+    account = new Account();
+    account.setId(1L);
+  }
+
+  private static Achievement scriptedAchievement(final String key, final String condition) {
+    Achievement achievement = new Achievement();
+    achievement.setKey(key);
+    achievement.setName(key);
+    achievement.setDescription(key);
+    achievement.setXpValue(10);
+    achievement.setCategory(AchievementCategory.SPECIAL_EVENT);
+    achievement.setUnlockCondition(condition);
+    return achievement;
+  }
+
+  @Test
+  @DisplayName(
+      "Achievement already held by the account is skipped before its script is compiled/evaluated")
+  void testAlreadyHeldAchievementSkipsScriptEvaluation() {
+    Achievement held = scriptedAchievement("ALREADY_HELD", "true");
+    account.setAchievements(new HashSet<>(List.of(held)));
+
+    when(definitionService.getScriptedAchievements()).thenReturn(List.of(held));
+
+    List<String> result = evaluator.resolveNewlyUnlockedKeys(account, Map.of());
+
+    assertThat(result).isEmpty();
+    verify(scriptService, never()).evaluate(anyString(), any());
+  }
+
+  @Test
+  @DisplayName("Unheld achievement whose script evaluates true is returned")
+  void testUnheldAchievementScriptTrueIsUnlocked() {
+    Achievement candidate = scriptedAchievement("NEW_ACHIEVEMENT", "wrestlers.size() >= 5");
+    when(definitionService.getScriptedAchievements()).thenReturn(List.of(candidate));
+    when(scriptService.evaluate(eq("wrestlers.size() >= 5"), any())).thenReturn(true);
+
+    List<String> result =
+        evaluator.resolveNewlyUnlockedKeys(account, Map.of("wrestlers", List.of()));
+
+    assertThat(result).containsExactly("NEW_ACHIEVEMENT");
+  }
+
+  @Test
+  @DisplayName("Unheld achievement whose script evaluates false is not returned")
+  void testUnheldAchievementScriptFalseIsNotUnlocked() {
+    Achievement candidate = scriptedAchievement("NEW_ACHIEVEMENT", "false");
+    when(definitionService.getScriptedAchievements()).thenReturn(List.of(candidate));
+    when(scriptService.evaluate(eq("false"), any())).thenReturn(false);
+
+    List<String> result = evaluator.resolveNewlyUnlockedKeys(account, Map.of());
+
+    assertThat(result).isEmpty();
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/service/challenge/ChallengeCompletionServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/challenge/ChallengeCompletionServiceTest.java
@@ -30,6 +30,7 @@ import com.github.javydreamercsw.management.domain.challenge.AccountChallengeCom
 import com.github.javydreamercsw.management.domain.challenge.AccountChallengeCompletionRepository;
 import com.github.javydreamercsw.management.domain.challenge.ChallengeCompletionStatus;
 import com.github.javydreamercsw.management.dto.challenge.ChallengeDTO;
+import com.github.javydreamercsw.management.service.achievement.ScriptedAchievementEvaluator;
 import com.github.javydreamercsw.management.service.legacy.LegacyService;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -46,13 +47,16 @@ class ChallengeCompletionServiceTest {
   @Mock private AccountChallengeCompletionRepository repository;
   @Mock private ChallengeService challengeService;
   @Mock private LegacyService legacyService;
+  @Mock private ScriptedAchievementEvaluator scriptedAchievementEvaluator;
 
   private ChallengeCompletionService service;
   private Account account;
 
   @BeforeEach
   void setUp() {
-    service = new ChallengeCompletionService(repository, challengeService, legacyService);
+    service =
+        new ChallengeCompletionService(
+            repository, challengeService, legacyService, scriptedAchievementEvaluator);
     account = new Account();
   }
 

--- a/src/test/java/com/github/javydreamercsw/management/service/legacy/AchievementScriptingIT.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/legacy/AchievementScriptingIT.java
@@ -1,0 +1,89 @@
+/*
+* Copyright (C) 2026 Software Consulting Dreams LLC
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <www.gnu.org>.
+*/
+package com.github.javydreamercsw.management.service.legacy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.javydreamercsw.base.domain.account.Account;
+import com.github.javydreamercsw.base.domain.account.AchievementRepository;
+import com.github.javydreamercsw.base.domain.wrestler.WrestlerTier;
+import com.github.javydreamercsw.management.domain.title.ChampionshipType;
+import com.github.javydreamercsw.management.domain.title.Title;
+import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
+import com.github.javydreamercsw.management.test.AbstractMockUserIntegrationTest;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Proves the full data-driven achievement path end-to-end with no mocks: achievements.json → {@code
+ * AchievementSync} → DB → {@code AchievementDefinitionService} (cache) → {@code
+ * AchievementScriptService} (Groovy) → {@code ScriptedAchievementEvaluator} → {@code
+ * LegacyService.unlockAchievement} → {@code AchievementUnlockedEvent}.
+ */
+@Transactional
+class AchievementScriptingIT extends AbstractMockUserIntegrationTest {
+
+  @Autowired private LegacyService legacyService;
+  @Autowired private AchievementRepository achievementRepository;
+  @Autowired private EntityManager entityManager;
+
+  @Test
+  void updateLegacyScore_rosterOf20WithThreeTitles_unlocksEliteScout() {
+    Account account = new Account("elite_scout_it_user", "P@ssword123", "elite_scout@example.com");
+    account = accountRepository.save(account);
+
+    List<Wrestler> roster = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      Wrestler wrestler = Wrestler.builder().build();
+      wrestler.setName("Elite Scout Wrestler " + i);
+      wrestler.setAccount(account);
+      roster.add(wrestlerRepository.save(wrestler));
+    }
+
+    for (int i = 0; i < 3; i++) {
+      Title title =
+          titleService.createTitle(
+              "Elite Scout Title " + i,
+              "Test title",
+              WrestlerTier.MAIN_EVENTER,
+              ChampionshipType.SINGLE,
+              defaultUniverse.getId());
+      title.awardTitleTo(List.of(roster.get(i)), Instant.now());
+      titleRepository.save(title);
+    }
+
+    // Flush + clear so the account/wrestler instances re-fetched inside updateLegacyScore are
+    // loaded fresh from the DB rather than returned from this transaction's identity map — the
+    // in-memory Wrestler.reigns collection (the inverse, mappedBy side of the awardTitleTo
+    // association) is never auto-synced on the already-managed instances above.
+    entityManager.flush();
+    entityManager.clear();
+
+    legacyService.updateLegacyScore(accountRepository.findById(account.getId()).orElseThrow());
+
+    Account reloaded = accountRepository.findById(account.getId()).orElseThrow();
+    assertThat(reloaded.getAchievements())
+        .as("ELITE_SCOUT is a script-only achievement (achievements.json), no Java trigger exists")
+        .anyMatch(a -> "ELITE_SCOUT".equals(a.getKey()));
+    assertThat(achievementRepository.findByKey("ELITE_SCOUT")).isPresent();
+  }
+}

--- a/src/test/java/com/github/javydreamercsw/management/service/legacy/AchievementSystemTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/legacy/AchievementSystemTest.java
@@ -39,6 +39,7 @@ import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerState;
 import com.github.javydreamercsw.management.event.AchievementUnlockedEvent;
 import com.github.javydreamercsw.management.service.GameSettingService;
+import com.github.javydreamercsw.management.service.achievement.ScriptedAchievementEvaluator;
 import com.github.javydreamercsw.management.service.campaign.WrestlerStatusService;
 import com.github.javydreamercsw.management.service.faction.FactionService;
 import com.github.javydreamercsw.management.service.feud.FeudResolutionService;
@@ -79,6 +80,7 @@ class AchievementSystemTest {
   @Mock private LeagueRosterRepository leagueRosterRepository;
   @Mock private TitleRepository titleRepository;
   @Mock private ApplicationEventPublisher eventPublisher;
+  @Mock private ScriptedAchievementEvaluator scriptedAchievementEvaluator;
 
   private LegacyService legacyService;
   private SegmentAdjudicationService segmentAdjudicationService;
@@ -106,7 +108,8 @@ class AchievementSystemTest {
             wrestlerRepository,
             achievementRepository,
             titleRepository,
-            eventPublisher);
+            eventPublisher,
+            scriptedAchievementEvaluator);
     segmentAdjudicationService =
         new SegmentAdjudicationService(
             new SegmentAdjudicationService.Dependencies(

--- a/src/test/java/com/github/javydreamercsw/management/service/legacy/LegacyServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/legacy/LegacyServiceTest.java
@@ -25,6 +25,7 @@ import com.github.javydreamercsw.base.domain.account.AchievementCategory;
 import com.github.javydreamercsw.base.domain.account.AchievementRepository;
 import com.github.javydreamercsw.management.domain.wrestler.Wrestler;
 import com.github.javydreamercsw.management.domain.wrestler.WrestlerRepository;
+import com.github.javydreamercsw.management.service.achievement.ScriptedAchievementEvaluator;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +42,7 @@ class LegacyServiceTest {
   @Mock private AchievementRepository achievementRepository;
   @Mock private com.github.javydreamercsw.management.domain.title.TitleRepository titleRepository;
   @Mock private ApplicationEventPublisher eventPublisher;
+  @Mock private ScriptedAchievementEvaluator scriptedAchievementEvaluator;
 
   @InjectMocks private LegacyService legacyService;
 
@@ -118,5 +120,31 @@ class LegacyServiceTest {
     // Should unlock Crowd Pleaser
     verify(accountRepository, atLeastOnce())
         .save(argThat(a -> a.getAchievements().contains(achievement) && a.getPrestige() == 100));
+  }
+
+  @Test
+  void testScriptedAchievementUnlocking() {
+    Account account = new Account();
+    account.setId(1L);
+    account.setUsername("testuser");
+
+    when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+    when(wrestlerRepository.findByAccount(account)).thenReturn(List.of());
+
+    Achievement scripted = new Achievement();
+    scripted.setKey("SCRIPTED_KEY");
+    scripted.setName("Scripted Achievement");
+    scripted.setXpValue(42);
+    scripted.setCategory(AchievementCategory.SPECIAL_EVENT);
+    scripted.setUnlockCondition("true");
+
+    when(scriptedAchievementEvaluator.resolveNewlyUnlockedKeys(eq(account), any()))
+        .thenReturn(List.of("SCRIPTED_KEY"));
+    when(achievementRepository.findByKey("SCRIPTED_KEY")).thenReturn(Optional.of(scripted));
+
+    legacyService.updateLegacyScore(account);
+
+    verify(accountRepository, atLeastOnce())
+        .save(argThat(a -> a.getAchievements().contains(scripted) && a.getPrestige() == 42));
   }
 }


### PR DESCRIPTION
## Summary
- Achievement metadata already lived in `achievements.json`, but unlock *logic* was 100% hardcoded Java spread across `LegacyService`, `ChallengeCompletionService`, and `SegmentAdjudicationService`.
- Adds an optional Groovy `unlockCondition` script on `Achievement` (`AchievementScriptService`, fail-closed, compiled-class cached — mirrors the existing `CampaignScriptService`/`CampaignChapterService` pattern), evaluated additively at the three existing check sites via `ScriptedAchievementEvaluator`.
- New achievements can now be authored entirely in `achievements.json` — including their trigger condition — for any condition shape those three sites already have data for. Zero behavior change to shipped/hardcoded achievements.
- Proof of pattern: `FIRST_WRESTLER` gained a script alongside its existing Java check; `ELITE_SCOUT` and `PLE_MAIN_EVENT_WINNER` are new **script-only** achievements with no corresponding Java trigger at all.
- `docs/CONTENT_GUIDE.md` documents the scripting mechanism and the per-site variable bindings, and `docs/CAMPAIGN_SCRIPTING.md` / `docs/DEVELOPER_GUIDE.md` now cross-reference it from the existing scripting/security docs so the new Groovy execution surface stays discoverable.

## Test plan
- [x] `AchievementScriptServiceTest` / `ScriptedAchievementEvaluatorTest` (new) — unit tests, including the dedup-before-compile guarantee
- [x] `LegacyServiceTest` / `ChallengeCompletionServiceTest` / `AchievementSystemTest` updated — existing hardcoded-achievement assertions pass unmodified
- [x] `AchievementScriptingIT` (new) — end-to-end integration test with a real DB, no mocks, proving `achievements.json` → sync → cache → Groovy eval → unlock → event publish
- [x] Full unit suite: 2895 tests, 0 failures (2 unrelated pre-existing Testcontainers/Docker MySQL env errors in `DatabaseManagerTest`/`DataMigrationServiceTest`, confirmed unrelated)
- [x] `mvn spotless:check` clean
- [x] New Flyway migrations (H2 V130, MySQL V99) — no released script touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8pRXxM1311ueSvsjiu19P