### PR TITLE
fix(ATW-ntjb.2): fix ChallengeUpdateService achievement-update path for scripted achievements

### DIFF
--- a/docs/CONTENT_GUIDE.md
+++ b/docs/CONTENT_GUIDE.md
@@ -393,6 +393,7 @@ For bundled challenges shipped in the JAR, the path is `images/challenges/filena
     {
       "id": "season_2_weekly",
       "jsonUrl": "https://javydreamercsw.github.io/all-time-wrestling-rpg/challenges/season_2/weekly_challenges.json",
+      "achievementsUrl": "https://javydreamercsw.github.io/all-time-wrestling-rpg/challenges/season_2/achievements.json",
       "images": [
         { "name": "week4.png", "url": "https://javydreamercsw.github.io/all-time-wrestling-rpg/challenges/images/week4.png" }
       ]
@@ -403,6 +404,7 @@ For bundled challenges shipped in the JAR, the path is `images/challenges/filena
 
 - `id` — unique package identifier (used to avoid re-downloading the same content).
 - `jsonUrl` — full GitHub Pages URL to the challenge JSON file.
+- `achievementsUrl` — optional. Full URL to an `achievements.json`-shaped file (same schema as [Achievements](#achievements), including `unlockCondition`). Applied via the same upsert logic as the bundled `achievements.json` — existing keys are updated in place, new keys are inserted. Omit if the package doesn't ship achievements.
 - `images` — list of images to download alongside this package. Already-downloaded images are skipped on repeat checks.
 - `lastUpdated` — human-readable date (informational only; the app always re-downloads changed packages).
 
@@ -544,6 +546,8 @@ Example — a script-only achievement with no corresponding Java, added purely v
 ```
 
 **Limitation:** a condition that needs data not available at any of the three sites above (e.g. "wrestler retires") still requires a new Java call site invoking `ScriptedAchievementEvaluator.resolveNewlyUnlockedKeys(...)` — this mechanism only covers the three existing choke points, not arbitrary new game events.
+
+Scripted achievements distributed via a remote content pack's `achievementsUrl` (see [Publishing new challenges without a release](#publishing-new-challenges-without-a-release)) work identically — `unlockCondition` is preserved whether an achievement is inserted or updated, and the in-memory cache of scripted achievements is refreshed immediately so an update takes effect without an app restart.
 
 ### Adding a new achievement
 

--- a/src/main/java/com/github/javydreamercsw/base/domain/account/Achievement.java
+++ b/src/main/java/com/github/javydreamercsw/base/domain/account/Achievement.java
@@ -22,6 +22,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.Setter;
 
 @Entity
@@ -67,4 +68,19 @@ public class Achievement extends AbstractEntity<Long> {
    */
   @Column(name = "unlock_condition", length = 2000)
   @Size(max = 2000) private String unlockCondition;
+
+  /**
+   * Copies the content-authored fields from {@code source} onto this achievement — used when
+   * upserting an existing achievement from achievements.json or a remote content pack. Identity
+   * fields ({@code id}, {@code key}) are left untouched. Single source of truth for which fields a
+   * content update is allowed to change, so the two independent upsert call sites (AchievementSync,
+   * ChallengeUpdateService) can't drift out of sync with each other.
+   */
+  public void copyContentFrom(@NonNull final Achievement source) {
+    this.name = source.name;
+    this.description = source.description;
+    this.xpValue = source.xpValue;
+    this.category = source.category;
+    this.unlockCondition = source.unlockCondition;
+  }
 }

--- a/src/main/java/com/github/javydreamercsw/management/service/challenge/ChallengeUpdateService.java
+++ b/src/main/java/com/github/javydreamercsw/management/service/challenge/ChallengeUpdateService.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javydreamercsw.base.domain.account.Achievement;
 import com.github.javydreamercsw.base.domain.account.AchievementRepository;
+import com.github.javydreamercsw.management.config.CacheConfig;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -35,6 +36,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -52,6 +54,7 @@ public class ChallengeUpdateService {
   private final ChallengeService challengeService;
   private final AchievementRepository achievementRepository;
   private final ObjectMapper objectMapper;
+  private final CacheManager cacheManager;
 
   @Getter private Instant lastChecked;
 
@@ -143,16 +146,21 @@ public class ChallengeUpdateService {
             .findByKey(a.getKey())
             .ifPresentOrElse(
                 existing -> {
-                  existing.setName(a.getName());
-                  existing.setDescription(a.getDescription());
-                  existing.setXpValue(a.getXpValue());
-                  existing.setCategory(a.getCategory());
+                  existing.copyContentFrom(a);
                   toSave.add(existing);
                 },
                 () -> toSave.add(a));
       }
       achievementRepository.saveAll(toSave);
       log.debug("Applied {} achievement(s) from {}", toSave.size(), url);
+      // Imperative eviction, not @CacheEvict: this method is reached both externally (the
+      // "check for updates" button) and via the self-invoked @Scheduled path, and Spring's
+      // proxy-based cache AOP does not intercept self-invocation.
+      var scriptedAchievementsCache =
+          cacheManager.getCache(CacheConfig.SCRIPTED_ACHIEVEMENTS_CACHE);
+      if (scriptedAchievementsCache != null) {
+        scriptedAchievementsCache.clear();
+      }
     } catch (Exception e) {
       log.error("Error applying achievements from {}", url, e);
     }

--- a/src/main/java/com/github/javydreamercsw/management/sync/AchievementSync.java
+++ b/src/main/java/com/github/javydreamercsw/management/sync/AchievementSync.java
@@ -68,11 +68,7 @@ public class AchievementSync implements DataSyncContributor {
           Optional<Achievement> existingOpt = achievementRepository.findByKey(a.getKey());
           if (existingOpt.isPresent()) {
             Achievement existing = existingOpt.get();
-            existing.setName(a.getName());
-            existing.setDescription(a.getDescription());
-            existing.setXpValue(a.getXpValue());
-            existing.setCategory(a.getCategory());
-            existing.setUnlockCondition(a.getUnlockCondition());
+            existing.copyContentFrom(a);
             toSave.add(existing);
           } else {
             toSave.add(a);

--- a/src/test/java/com/github/javydreamercsw/management/service/challenge/ChallengeUpdateServiceTest.java
+++ b/src/test/java/com/github/javydreamercsw/management/service/challenge/ChallengeUpdateServiceTest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javydreamercsw.base.domain.account.Achievement;
 import com.github.javydreamercsw.base.domain.account.AchievementRepository;
+import com.github.javydreamercsw.management.config.CacheConfig;
 import com.github.javydreamercsw.management.service.challenge.ChallengeUpdateService.UpdateResult;
 import com.sun.net.httpserver.HttpServer;
 import java.net.InetSocketAddress;
@@ -45,6 +46,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,6 +56,8 @@ class ChallengeUpdateServiceTest {
   @TempDir Path contentDir;
   @Mock ChallengeService challengeService;
   @Mock AchievementRepository achievementRepository;
+  @Mock CacheManager cacheManager;
+  @Mock Cache scriptedAchievementsCache;
 
   private ChallengeUpdateService updateService;
 
@@ -64,9 +69,13 @@ class ChallengeUpdateServiceTest {
   @BeforeEach
   void setUp() {
     lenient().when(challengeService.getContentDir()).thenReturn(contentDir);
+    lenient()
+        .when(cacheManager.getCache(CacheConfig.SCRIPTED_ACHIEVEMENTS_CACHE))
+        .thenReturn(scriptedAchievementsCache);
     ObjectMapper mapper =
         new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    updateService = new ChallengeUpdateService(challengeService, achievementRepository, mapper);
+    updateService =
+        new ChallengeUpdateService(challengeService, achievementRepository, mapper, cacheManager);
   }
 
   @Test
@@ -198,7 +207,7 @@ class ChallengeUpdateServiceTest {
 
     String achievementsJson =
         "[{\"key\":\"TEST_ACH\",\"name\":\"Test\",\"description\":\"Desc\","
-            + "\"xpValue\":50,\"category\":\"CHALLENGE\"}]";
+            + "\"xpValue\":50,\"category\":\"CHALLENGE\",\"unlockCondition\":\"true\"}]";
     String manifest =
         "{\"schemaVersion\":1,\"lastUpdated\":\"2026-08-01\",\"packages\":["
             + "{\"id\":\"pkg1\",\"jsonUrl\":\"http://localhost:"
@@ -221,7 +230,12 @@ class ChallengeUpdateServiceTest {
     try {
       setManifestUrl(server, "/manifest.json");
       updateService.checkAndApply();
-      verify(achievementRepository).saveAll(any(List.class));
+      @SuppressWarnings("unchecked")
+      var captor = org.mockito.ArgumentCaptor.forClass(List.class);
+      verify(achievementRepository).saveAll(captor.capture());
+      Achievement saved = (Achievement) captor.getValue().get(0);
+      assertEquals("true", saved.getUnlockCondition());
+      verify(scriptedAchievementsCache).clear();
     } finally {
       server.stop(0);
     }
@@ -233,8 +247,9 @@ class ChallengeUpdateServiceTest {
     int port = server.getAddress().getPort();
 
     String achievementsJson =
-        "[{\"key\":\"EXISTING_ACH\",\"name\":\"Updated Name\",\"description\":\"New Desc\","
-            + "\"xpValue\":75,\"category\":\"CHALLENGE\"}]";
+        "[{\"key\":\"EXISTING_ACH\",\"name\":\"Updated Name\",\"description\":\"New"
+            + " Desc\",\"xpValue\":75,\"category\":\"CHALLENGE\",\"unlockCondition\":\"wrestlers.size()"
+            + " >= 5\"}]";
     String manifest =
         "{\"schemaVersion\":1,\"lastUpdated\":\"2026-08-01\",\"packages\":["
             + "{\"id\":\"pkg1\",\"jsonUrl\":\"http://localhost:"
@@ -256,6 +271,7 @@ class ChallengeUpdateServiceTest {
     existing.setName("Old Name");
     existing.setDescription("Old Desc");
     existing.setXpValue(50);
+    existing.setUnlockCondition(null);
     when(achievementRepository.findByKey("EXISTING_ACH")).thenReturn(Optional.of(existing));
     when(achievementRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -265,7 +281,9 @@ class ChallengeUpdateServiceTest {
       assertEquals("Updated Name", existing.getName());
       assertEquals("New Desc", existing.getDescription());
       assertEquals(75, existing.getXpValue());
+      assertEquals("wrestlers.size() >= 5", existing.getUnlockCondition());
       verify(achievementRepository).saveAll(any(List.class));
+      verify(scriptedAchievementsCache).clear();
     } finally {
       server.stop(0);
     }
@@ -298,6 +316,7 @@ class ChallengeUpdateServiceTest {
       UpdateResult result = updateService.checkAndApply();
       assertEquals(1, result.downloaded());
       verify(achievementRepository, never()).saveAll(any());
+      verify(scriptedAchievementsCache, never()).clear();
     } finally {
       server.stop(0);
     }


### PR DESCRIPTION
## Summary
- Follow-up to #460 (data-driven achievement unlock conditions). `ChallengeUpdateService.applyAchievements()` — the remote content-pack achievement sync, triggered via a package's `achievementsUrl` or the scheduled/manual "Check for Updates" flow — duplicated `AchievementSync`'s upsert logic independently, and had two gaps:
  1. **`unlockCondition` silently dropped on update.** Updating an *existing* achievement key via a remote pack never copied the script field, so a content update that added/changed a scripted condition on an already-synced achievement would be silently ignored. New achievement keys were unaffected (Jackson deserializes the field fine on insert).
  2. **No cache eviction.** `SCRIPTED_ACHIEVEMENTS_CACHE` was never evicted after applying, so even a correct update wouldn't be picked up by evaluation until the 10-minute Caffeine TTL expired.
- Extracts `Achievement.copyContentFrom(Achievement)` as the single source of truth for which fields a content update is allowed to change, used by both `AchievementSync` and `ChallengeUpdateService` so the two independent upsert sites can't drift apart again.
- Cache eviction is done imperatively via injected `CacheManager` rather than `@CacheEvict` — `applyAchievements()` is reached both externally (the UI "check for updates" button) and via the self-invoked `@Scheduled` path, and Spring's proxy-based cache AOP does not intercept self-invocation, so the annotation would have silently failed to fire on the scheduled path.
- `docs/CONTENT_GUIDE.md`: documents the previously-undocumented `achievementsUrl` field on `ChallengeContentManifest.ChallengePackage`, and cross-references it from the scripted-unlock-conditions section.

## Test plan
- [x] `ChallengeUpdateServiceTest` — extended `checkAndApply_withAchievementsUrl_updatesExistingAchievement` to assert `unlockCondition` is now copied on update and the cache is evicted; extended `checkAndApply_withAchievementsUrl_insertsNewAchievement` to assert the script survives insert and the cache is evicted; extended `checkAndApply_withAchievementsUrl_handlesUnreachableAchievementsGracefully` to assert the cache is *not* touched when the fetch fails
- [x] Full unit suite: 2895 tests, 0 failures (2 unrelated pre-existing Testcontainers/Docker MySQL env errors, same as #460)
- [x] `mvn spotless:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8pRXxM1311ueSvsjiu19P