### PR TITLE
feat(ATW-wg7n): add 20 scripted achievements for roster identity and systemic gaps

### DIFF
--- a/src/main/resources/achievements.json
+++ b/src/main/resources/achievements.json
@@ -493,4 +493,144 @@
   "description": "Won \"The Match Beyond\" as the underdog team",
   "xpValue": 150,
   "category": "CHALLENGE"
+}, {
+  "key": "RISING_TIDE",
+  "name": "Rising Tide",
+  "description": "Accumulate 50,000 total fans across your roster",
+  "xpValue": 250,
+  "category": "FANS",
+  "unlockCondition": "totalFans >= 50000"
+}, {
+  "key": "ARENA_FILLER",
+  "name": "Arena Filler",
+  "description": "Accumulate 500,000 total fans across your roster",
+  "xpValue": 2000,
+  "category": "FANS",
+  "unlockCondition": "totalFans >= 500000"
+}, {
+  "key": "LOADED_ROSTER_25",
+  "name": "Full Locker Room",
+  "description": "Sign your 25th wrestler",
+  "xpValue": 500,
+  "category": "COLLECTION",
+  "unlockCondition": "wrestlers.size() >= 25"
+}, {
+  "key": "DOUBLE_GOLD",
+  "name": "Double Gold",
+  "description": "Have two championships held simultaneously across your roster",
+  "xpValue": 750,
+  "category": "CHAMPIONSHIP",
+  "unlockCondition": "currentTitlesHeld >= 2"
+}, {
+  "key": "TRIPLE_CROWN",
+  "name": "Triple Crown",
+  "description": "Hold three championships at once across your roster",
+  "xpValue": 1500,
+  "category": "CHAMPIONSHIP",
+  "unlockCondition": "currentTitlesHeld >= 3"
+}, {
+  "key": "SILVER_TONGUE_CHAMPION",
+  "name": "Silver Tongue",
+  "description": "A wrestler with elite Charisma (5+) holds a championship",
+  "xpValue": 500,
+  "category": "CHAMPIONSHIP",
+  "unlockCondition": "wrestlers.any { w -> w.charisma >= 5 && w.reigns?.any { r -> r.currentReign } }"
+}, {
+  "key": "BRAWLER_KING",
+  "name": "Brawler King",
+  "description": "A wrestler with elite Brawl (5+) holds a championship",
+  "xpValue": 500,
+  "category": "CHAMPIONSHIP",
+  "unlockCondition": "wrestlers.any { w -> w.brawl >= 5 && w.reigns?.any { r -> r.currentReign } }"
+}, {
+  "key": "DRIVEN_TO_THE_TOP",
+  "name": "Driven to the Top",
+  "description": "A wrestler with elite Drive (5+) holds a championship",
+  "xpValue": 600,
+  "category": "CHAMPIONSHIP",
+  "unlockCondition": "wrestlers.any { w -> w.drive >= 5 && w.reigns?.any { r -> r.currentReign } }"
+}, {
+  "key": "UNBREAKABLE",
+  "name": "Unbreakable",
+  "description": "A wrestler with elite Resilience (5+) holds a championship",
+  "xpValue": 500,
+  "category": "CHAMPIONSHIP",
+  "unlockCondition": "wrestlers.any { w -> w.resilience >= 5 && w.reigns?.any { r -> r.currentReign } }"
+}, {
+  "key": "COMPLETE_PACKAGE",
+  "name": "The Complete Package",
+  "description": "Have a wrestler with Drive, Resilience, Charisma, and Brawl all at 4 or higher",
+  "xpValue": 750,
+  "category": "COLLECTION",
+  "unlockCondition": "wrestlers.any { w -> w.drive >= 4 && w.resilience >= 4 && w.charisma >= 4 && w.brawl >= 4 }"
+}, {
+  "key": "GLASS_CANNON_CHAMPION",
+  "name": "Glass Cannon Champion",
+  "description": "A low-health wrestler (starting health 8 or below) holds a championship",
+  "xpValue": 600,
+  "category": "CHAMPIONSHIP",
+  "unlockCondition": "wrestlers.any { w -> w.startingHealth <= 8 && w.reigns?.any { r -> r.currentReign } }"
+}, {
+  "key": "IRON_LUNGS_CHAMPION",
+  "name": "Iron Lungs",
+  "description": "A high-stamina wrestler (starting stamina 16 or above) holds a championship",
+  "xpValue": 500,
+  "category": "CHAMPIONSHIP",
+  "unlockCondition": "wrestlers.any { w -> w.startingStamina >= 16 && w.reigns?.any { r -> r.currentReign } }"
+}, {
+  "key": "DEEP_TALENT",
+  "name": "Bag of Tricks",
+  "description": "A wrestler with a near-full deck (17+ cards) holds a championship",
+  "xpValue": 400,
+  "category": "CHAMPIONSHIP",
+  "unlockCondition": "wrestlers.any { w -> w.deckSize >= 17 && w.reigns?.any { r -> r.currentReign } }"
+}, {
+  "key": "GLOBAL_ROSTER",
+  "name": "Global Scouting Report",
+  "description": "Have active wrestlers from three or more different heritage regions",
+  "xpValue": 400,
+  "category": "COLLECTION",
+  "unlockCondition": "wrestlers.findAll { it.heritageTag && it.active }.collect { it.heritageTag }.unique().size() >= 3"
+}, {
+  "key": "HOMETOWN_PRIDE",
+  "name": "Hometown Pride",
+  "description": "Have two or more current champions all from the same heritage region",
+  "xpValue": 800,
+  "category": "CHAMPIONSHIP",
+  "unlockCondition": "def champs = wrestlers.findAll { w -> w.reigns?.any { r -> r.currentReign } }; champs.size() >= 2 && champs.every { it.heritageTag } && champs.collect { it.heritageTag }.unique().size() == 1"
+}, {
+  "key": "HOMEGROWN_CHAMPION",
+  "name": "Homegrown Champion",
+  "description": "A custom-expansion wrestler holds a championship",
+  "xpValue": 750,
+  "category": "CHAMPIONSHIP",
+  "unlockCondition": "wrestlers.any { w -> w.expansionCode == 'CUSTOM' && w.reigns?.any { r -> r.currentReign } }"
+}, {
+  "key": "WOMEN_RULE",
+  "name": "The Glass Ceiling, Shattered",
+  "description": "A female wrestler holds a championship",
+  "xpValue": 500,
+  "category": "CHAMPIONSHIP",
+  "unlockCondition": "wrestlers.any { w -> w.gender?.name() == 'FEMALE' && w.reigns?.any { r -> r.currentReign } }"
+}, {
+  "key": "OLYMPIC_GOLD",
+  "name": "Olympic Gold",
+  "description": "Have Kurt Angle win a championship",
+  "xpValue": 750,
+  "category": "SPECIAL_EVENT",
+  "unlockCondition": "wrestlers.any { w -> w.name?.toLowerCase()?.contains('angle') && w.reigns?.any { r -> r.currentReign } }"
+}, {
+  "key": "GIANT_AMONG_CHAMPIONS",
+  "name": "A Giant Among Champions",
+  "description": "Have André the Giant hold a championship",
+  "xpValue": 1000,
+  "category": "SPECIAL_EVENT",
+  "unlockCondition": "wrestlers.any { w -> w.name?.toLowerCase()?.contains('andr') && w.reigns?.any { r -> r.currentReign } }"
+}, {
+  "key": "MACHO_MADNESS",
+  "name": "Macho Madness",
+  "description": "Have Randy Savage hold a championship",
+  "xpValue": 750,
+  "category": "SPECIAL_EVENT",
+  "unlockCondition": "wrestlers.any { w -> w.name?.toLowerCase()?.contains('savage') && w.reigns?.any { r -> r.currentReign } }"
 } ]


### PR DESCRIPTION
## Summary

- Adds 20 new achievements to `achievements.json` using the existing Groovy scripted evaluator — **zero Java code changed**
- Fills identified gaps in fan milestones, roster progression, and championship coverage
- Introduces wrestler-identity achievements driven by campaign stats, physical stats, heritage, gender, expansion code, and named-wrestler name matching

## What's included

**Systemic gap-fillers (5)**
- `RISING_TIDE` / `ARENA_FILLER` — fan milestones at 50k and 500k (bridges the 900k gap between existing checkpoints)
- `LOADED_ROSTER_25` — bridges `ROSTER_BUILDER` (10) and `FULL_HOUSE` (50)
- `DOUBLE_GOLD` / `TRIPLE_CROWN` — simultaneous multi-title hold milestones

**Campaign attribute champions (4)**
- `SILVER_TONGUE_CHAMPION`, `BRAWLER_KING`, `DRIVEN_TO_THE_TOP`, `UNBREAKABLE` — each fires when a wrestler with that stat at **5+** holds a championship

**Physical archetype champions (3)**
- `GLASS_CANNON_CHAMPION` (startingHealth ≤ 8), `IRON_LUNGS_CHAMPION` (startingStamina ≥ 16), `DEEP_TALENT` (deckSize ≥ 17)

**Roster identity (4)**
- `COMPLETE_PACKAGE` — wrestler with all four campaign stats ≥ 4
- `GLOBAL_ROSTER` — 3+ heritage regions on active roster
- `WOMEN_RULE` — female wrestler holds a championship
- `HOMETOWN_PRIDE` — 2+ current champions from same heritage region

**Expansion (2)**
- `HOMEGROWN_CHAMPION` — `CUSTOM` expansion wrestler holds a title

**Named-wrestler flavor (3)**
- `OLYMPIC_GOLD` (Kurt Angle), `GIANT_AMONG_CHAMPIONS` (André the Giant), `MACHO_MADNESS` (Randy Savage)

## Implementation notes

All 20 achievements use `unlockCondition` Groovy scripts evaluated by the existing `ScriptedAchievementEvaluator` / `AchievementScriptService` pipeline. Scripts run within the active Hibernate transaction so lazy-loaded `reigns` collections are safe. The evaluator fails closed — any script exception is logged and treated as not-unlocked, so a malformed condition can never block gameplay.

## Not in this PR (follow-up)

- Tier 2: show-count milestones, ICON_MAKER, IRON_CHAMPION, DYNASTY_BUILDER (need new repository queries wired into existing services)
- Tier 3: rivalry, retirement, faction, relationship listeners (new `ApplicationListener` per event)
- Extended segment context: momentum and stat-specific match-win achievements (need `ScriptedAchievementEvaluator` call added to `SegmentAdjudicationService.triggerAchievements()`)
- Named achievements for remaining 31 wrestlers (tracked under ATW-wg7n subtasks)

## Test plan

- [x] `AchievementScriptServiceTest` — 7 tests pass
- [x] `ScriptedAchievementEvaluatorTest` — 3 tests pass
- [x] `DataInitializerTest` — 20 tests pass (JSON loads and upserts cleanly)
- [x] `ChallengeUpdateServiceTest` — 9 tests pass
- [x] `spotless:apply` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SvWxTNAM7kfVWapXsD5gg